### PR TITLE
Remove duplicated `review_id` property.

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -874,8 +874,6 @@ definitions:
             type: string
         error_message:
           type: string
-        review_id:
-          type: string
         branch:
           type: string
         commit_ref:


### PR DESCRIPTION
There was a duplicated _review_id_ property in the _deploy_ definition.
This causes a problem with some tools that rely on successful parsing of the swagger file. For example [JS-YAML](http://nodeca.github.io/js-yaml/)