### PR TITLE
Allow setting a session_id when creating a new site

### DIFF
--- a/go/models/site.go
+++ b/go/models/site.go
@@ -58,6 +58,9 @@ type Site struct {
 	// screenshot url
 	ScreenshotURL string `json:"screenshot_url,omitempty"`
 
+	// session id
+	SessionID string `json:"session_id,omitempty"`
+
 	// ssl
 	Ssl bool `json:"ssl,omitempty"`
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -826,6 +826,8 @@ definitions:
           format: dateTime
         user_id:
           type: string
+        session_id:
+          type: string
         ssl:
           type: boolean
         force_ssl:

--- a/ui/swagger.json
+++ b/ui/swagger.json
@@ -1612,6 +1612,9 @@
         "screenshot_url": {
           "type": "string"
         },
+        "session_id": {
+          "type": "string"
+        },
         "ssl": {
           "type": "boolean"
         },


### PR DESCRIPTION
This allows easy handover to a final netlify users at a later point