### PR TITLE
Add deploy callbacks.

### DIFF
--- a/go/Gopkg.lock
+++ b/go/Gopkg.lock
@@ -16,8 +16,8 @@
 [[projects]]
   name = "github.com/asaskevich/govalidator"
   packages = ["."]
-  revision = "73945b6115bfbbcc57d89b7316e28109364124e1"
-  version = "v7"
+  revision = "521b25f4b05fd26bec69d9dedeb8f9c9a83939a8"
+  version = "v8"
 
 [[projects]]
   name = "github.com/cenkalti/backoff"
@@ -58,14 +58,14 @@
 [[projects]]
   branch = "master"
   name = "github.com/go-openapi/runtime"
-  packages = [".","client"]
-  revision = "e8231e16de5bcda9839e03ae07c5c96a1fd82041"
+  packages = [".","client","logger","middleware","middleware/denco","middleware/header","middleware/untyped","security"]
+  revision = "96511efa8f2190cf4dd04412c61a1a96546b36d9"
 
 [[projects]]
   branch = "master"
   name = "github.com/go-openapi/spec"
   packages = ["."]
-  revision = "84b5bee7bcb76f3d17bcbaf421bac44bd5709ca6"
+  revision = "a4fa9574c7aa73b2fc54e251eb9524d0482bb592"
 
 [[projects]]
   branch = "master"
@@ -77,19 +77,19 @@
   branch = "master"
   name = "github.com/go-openapi/swag"
   packages = ["."]
-  revision = "f3f9494671f93fcff853e3c6e9e948b3eb71e590"
+  revision = "cf0bdb963811675a4d7e74901cefc7411a1df939"
 
 [[projects]]
   branch = "master"
   name = "github.com/go-openapi/validate"
   packages = ["."]
-  revision = "b6cfc35bf312e6fb320d85ed9fc3ac408dcb8694"
+  revision = "a52193aca9d575f354d8be388254c134765ea793"
 
 [[projects]]
   branch = "master"
   name = "github.com/mailru/easyjson"
   packages = ["buffer","jlexer","jwriter"]
-  revision = "4d347d79dea0067c945f374f990601decb08abb5"
+  revision = "5f62e4f3afa2f576dc86531b7df4d966b19ef8f8"
 
 [[projects]]
   branch = "master"
@@ -107,25 +107,25 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "2509b142fb2b797aa7587dad548f113b2c0f20ce"
+  revision = "6a293f2d4b14b8e6d3f0539e383f6d0d30fce3fd"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context","context/ctxhttp","idna"]
-  revision = "c73622c77280266305273cb545f54516ced95b93"
+  revision = "a337091b0525af65de94df2eb7e98bd9962dcbe2"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix","windows"]
-  revision = "661970f62f5897bc0cd5fdca7e087ba8a98a8fa1"
+  revision = "1e2299c37cc91a509f1b12369872d27be0ce98a6"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
   packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable","width"]
-  revision = "6eab0e8f74e86c598ec3b6fad4888e0c11482d48"
+  revision = "88f656faf3f37f690df1a32515b479415e1a6769"
 
 [[projects]]
   branch = "v2"

--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -32,10 +32,22 @@ const (
 
 type uploadType int
 
+type DeployCallback func(*models.Deploy) error
+type UploadCallback func(*FileBundle) error
+type FailedUploadCallback func(*FileBundle, error) error
+
 const (
 	fileUpload uploadType = iota
 	functionUpload
 )
+
+type DeployCallbacks struct {
+	OnSetupDeploy DeployCallback
+
+	OnSetupUpload      UploadCallback
+	OnSuccessfulUpload UploadCallback
+	OnFailedUpload     FailedUploadCallback
+}
 
 // DeployOptions holds the option for creating a new deploy
 type DeployOptions struct {
@@ -49,6 +61,8 @@ type DeployOptions struct {
 	Branch    string
 	CommitRef string
 
+	Callbacks *DeployCallbacks
+
 	files     *deployFiles
 	functions *deployFiles
 }
@@ -58,29 +72,29 @@ type uploadError struct {
 	mutex *sync.Mutex
 }
 
-type file struct {
+type FileBundle struct {
 	Name string
 	SHA  hash.Hash
 
 	Buffer io.ReadSeeker
 }
 
-func (f *file) Sum() string {
+func (f *FileBundle) Sum() string {
 	return hex.EncodeToString(f.SHA.Sum(nil))
 }
 
-func (f *file) Read(p []byte) (n int, err error) {
+func (f *FileBundle) Read(p []byte) (n int, err error) {
 	return f.Buffer.Read(p)
 }
 
-func (f *file) Close() error {
+func (f *FileBundle) Close() error {
 	return nil
 }
 
 // We're mocking up a closer, to make sure the underlying file handle
 // doesn't get closed during an upload, but can be rewinded for retries
 // This method closes the file handle for real.
-func (f *file) CloseForReal() error {
+func (f *FileBundle) CloseForReal() error {
 	closer, ok := f.Buffer.(io.Closer)
 	if ok {
 		return closer.Close()
@@ -88,26 +102,26 @@ func (f *file) CloseForReal() error {
 	return nil
 }
 
-func (f *file) Rewind() error {
+func (f *FileBundle) Rewind() error {
 	_, err := f.Buffer.Seek(0, 0)
 	return err
 }
 
 type deployFiles struct {
-	Files  map[string]*file
+	Files  map[string]*FileBundle
 	Sums   map[string]string
-	Hashed map[string][]*file
+	Hashed map[string][]*FileBundle
 }
 
 func newDeployFiles() *deployFiles {
 	return &deployFiles{
-		Files:  make(map[string]*file),
+		Files:  make(map[string]*FileBundle),
 		Sums:   make(map[string]string),
-		Hashed: make(map[string][]*file),
+		Hashed: make(map[string][]*FileBundle),
 	}
 }
 
-func (d *deployFiles) Add(p string, f *file) {
+func (d *deployFiles) Add(p string, f *FileBundle) {
 	sum := f.Sum()
 
 	d.Files[p] = f
@@ -206,12 +220,18 @@ func (n *Netlify) DoDeploy(ctx context.Context, options *DeployOptions, deploy *
 		return deploy, nil
 	}
 
-	if err := n.uploadFiles(ctx, deploy, options.files, fileUpload); err != nil {
+	if options.Callbacks != nil && options.Callbacks.OnSetupDeploy != nil {
+		if err := options.Callbacks.OnSetupDeploy(deploy); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := n.uploadFiles(ctx, deploy, options.files, options.Callbacks, fileUpload); err != nil {
 		return nil, err
 	}
 
 	if options.functions != nil {
-		if err := n.uploadFiles(ctx, deploy, options.functions, functionUpload); err != nil {
+		if err := n.uploadFiles(ctx, deploy, options.functions, options.Callbacks, functionUpload); err != nil {
 			return nil, err
 		}
 	}
@@ -253,7 +273,7 @@ func (n *Netlify) WaitUntilDeployReady(ctx context.Context, d *models.Deploy) (*
 	return d, nil
 }
 
-func (n *Netlify) uploadFiles(ctx context.Context, d *models.Deploy, files *deployFiles, t uploadType) error {
+func (n *Netlify) uploadFiles(ctx context.Context, d *models.Deploy, files *deployFiles, callbacks *DeployCallbacks, t uploadType) error {
 	sharedErr := &uploadError{err: nil, mutex: &sync.Mutex{}}
 	sem := make(chan int, n.uploadLimit)
 	wg := &sync.WaitGroup{}
@@ -283,7 +303,7 @@ func (n *Netlify) uploadFiles(ctx context.Context, d *models.Deploy, files *depl
 				sem <- 1
 				wg.Add(1)
 
-				go n.uploadFile(ctx, d, file, t, wg, sem, sharedErr)
+				go n.uploadFile(ctx, d, file, callbacks, t, wg, sem, sharedErr)
 			}
 		}
 	}
@@ -293,7 +313,7 @@ func (n *Netlify) uploadFiles(ctx context.Context, d *models.Deploy, files *depl
 	return sharedErr.err
 }
 
-func (n *Netlify) uploadFile(ctx context.Context, d *models.Deploy, f *file, t uploadType, wg *sync.WaitGroup, sem chan int, sharedErr *uploadError) {
+func (n *Netlify) uploadFile(ctx context.Context, d *models.Deploy, f *FileBundle, c *DeployCallbacks, t uploadType, wg *sync.WaitGroup, sem chan int, sharedErr *uploadError) {
 	defer func() {
 		wg.Done()
 		<-sem
@@ -316,6 +336,15 @@ func (n *Netlify) uploadFile(ctx context.Context, d *models.Deploy, f *file, t u
 
 	b := backoff.NewExponentialBackOff()
 	b.MaxElapsedTime = 2 * time.Minute
+
+	if c != nil && c.OnSetupUpload != nil {
+		if err := c.OnSetupUpload(f); err != nil {
+			sharedErr.mutex.Lock()
+			sharedErr.err = err
+			sharedErr.mutex.Unlock()
+			return
+		}
+	}
 
 	err := backoff.Retry(func() error {
 		sharedErr.mutex.Lock()
@@ -357,9 +386,21 @@ func (n *Netlify) uploadFile(ctx context.Context, d *models.Deploy, f *file, t u
 	}, b)
 
 	if err != nil {
+		if c != nil && c.OnFailedUpload != nil {
+			c.OnFailedUpload(f, err)
+		}
+
 		sharedErr.mutex.Lock()
 		sharedErr.err = err
 		sharedErr.mutex.Unlock()
+	} else {
+		if c != nil && c.OnSuccessfulUpload != nil {
+			if err := c.OnSuccessfulUpload(f); err != nil {
+				sharedErr.mutex.Lock()
+				sharedErr.err = err
+				sharedErr.mutex.Unlock()
+			}
+		}
 	}
 }
 
@@ -386,7 +427,7 @@ func walk(dir string) (*deployFiles, error) {
 				return err
 			}
 
-			file := &file{
+			file := &FileBundle{
 				Name: rel,
 				SHA:  sha1.New(),
 			}
@@ -419,7 +460,7 @@ func bundle(functionDir string) (*deployFiles, error) {
 	for _, i := range info {
 		switch filepath.Ext(i.Name()) {
 		case ".js":
-			file := &file{
+			file := &FileBundle{
 				Name: strings.TrimSuffix(i.Name(), filepath.Ext(i.Name())),
 				SHA:  sha256.New(),
 			}


### PR DESCRIPTION
This allows to execute arbitrary logic during a deploy lifecycle.
Useful to generate progress reports and track file uploads in real time.

Signed-off-by: David Calavera <david.calavera@gmail.com>