### PR TITLE
Add Site#capabilities

### DIFF
--- a/go/models/site.go
+++ b/go/models/site.go
@@ -29,6 +29,9 @@ type Site struct {
 	// build settings
 	BuildSettings *SiteBuildSettings `json:"build_settings,omitempty"`
 
+	// capabilities
+	Capabilities map[string]interface{} `json:"capabilities,omitempty"`
+
 	// created at
 	CreatedAt string `json:"created_at,omitempty"`
 
@@ -103,6 +106,8 @@ type Site struct {
 /* polymorph site admin_url false */
 
 /* polymorph site build_settings false */
+
+/* polymorph site capabilities false */
 
 /* polymorph site created_at false */
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -1213,6 +1213,10 @@ definitions:
           type: string
         deploy_hook:
           type: string
+        capabilities:
+          type: object
+          additionalProperties:
+            type: object
         build_settings:
           type: object
           properties:

--- a/ui/swagger.json
+++ b/ui/swagger.json
@@ -2521,6 +2521,12 @@
             }
           }
         },
+        "capabilities": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
         "created_at": {
           "type": "string",
           "format": "dateTime"


### PR DESCRIPTION
This is attribute is an alias for the legacy site_plan that matches
other objects, like account.

Fixes #49

Signed-off-by: David Calavera <david.calavera@gmail.com>