### PR TITLE
Unify repository path accessors with RepoPath.

### DIFF
--- a/go/models/repo_info.go
+++ b/go/models/repo_info.go
@@ -44,11 +44,11 @@ type RepoInfo struct {
 	// public repo
 	PublicRepo bool `json:"public_repo,omitempty"`
 
-	// repo
-	Repo string `json:"repo,omitempty"`
-
 	// repo branch
 	RepoBranch string `json:"repo_branch,omitempty"`
+
+	// repo path
+	RepoPath string `json:"repo_path,omitempty"`
 
 	// repo url
 	RepoURL string `json:"repo_url,omitempty"`
@@ -72,9 +72,9 @@ type RepoInfo struct {
 
 /* polymorph repoInfo public_repo false */
 
-/* polymorph repoInfo repo false */
-
 /* polymorph repoInfo repo_branch false */
+
+/* polymorph repoInfo repo_path false */
 
 /* polymorph repoInfo repo_url false */
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -1422,7 +1422,7 @@ definitions:
           type: string
         deploy_key_id:
           type: string
-        repo:
+        repo_path:
           type: string
         repo_branch:
           type: string

--- a/ui/swagger.json
+++ b/ui/swagger.json
@@ -2788,10 +2788,10 @@
         "public_repo": {
           "type": "boolean"
         },
-        "repo": {
+        "repo_branch": {
           "type": "string"
         },
-        "repo_branch": {
+        "repo_path": {
           "type": "string"
         },
         "repo_url": {


### PR DESCRIPTION
POST and GET use the same attribute to access this information.

Fixes #64
/cc @mitchellh

Signed-off-by: David Calavera <david.calavera@gmail.com>