### PR TITLE
Implement an http transport that retries after a rate limit.

### DIFF
--- a/go/Gopkg.lock
+++ b/go/Gopkg.lock
@@ -2,6 +2,12 @@
 
 
 [[projects]]
+  name = "github.com/Azure/go-autorest"
+  packages = ["autorest","autorest/adal","autorest/date"]
+  revision = "809ed2ef5c4c9a60c3c2f3aa9cc11f3a7c2ce59d"
+  version = "v9.6.0"
+
+[[projects]]
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
   revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
@@ -24,6 +30,12 @@
   packages = ["."]
   revision = "61153c768f31ee5f130071d08fc82b85208528de"
   version = "v1.1.0"
+
+[[projects]]
+  name = "github.com/dgrijalva/jwt-go"
+  packages = ["."]
+  revision = "dbeaa9332f19a944acb5736b4456cfcc02140e29"
+  version = "v3.1.0"
 
 [[projects]]
   branch = "master"
@@ -142,6 +154,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "50bf31719a306ecfaa7fab7a67beadb722b2a539e79c8becfba422d9c99d36d2"
+  inputs-digest = "e9b30bc075025eb805c0e58cd5158e058c12cc5a9626f4a856b6a67cdf159a59"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/go/Gopkg.lock
+++ b/go/Gopkg.lock
@@ -32,6 +32,12 @@
   version = "v1.1.0"
 
 [[projects]]
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
+  version = "v1.1.0"
+
+[[projects]]
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
   revision = "dbeaa9332f19a944acb5736b4456cfcc02140e29"
@@ -110,10 +116,22 @@
   revision = "06020f85339e21b2478f756a78e295255ffa4d6a"
 
 [[projects]]
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   revision = "f006c2ac4710855cf0f916dd6b77acf6b048dc6e"
   version = "v1.0.3"
+
+[[projects]]
+  name = "github.com/stretchr/testify"
+  packages = ["assert","require"]
+  revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
+  version = "v1.1.4"
 
 [[projects]]
   branch = "master"
@@ -154,6 +172,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e9b30bc075025eb805c0e58cd5158e058c12cc5a9626f4a856b6a67cdf159a59"
+  inputs-digest = "37aa9ade4f7ae265a41655eb76daecc45205975d6e80bc9a8412d655c0775f2d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/go/Gopkg.toml
+++ b/go/Gopkg.toml
@@ -52,3 +52,7 @@
 [[constraint]]
   name = "github.com/Azure/go-autorest"
   version = "v9.6.0"
+
+[[constraint]]
+  name = "github.com/stretchr/testify"
+  version = "v1.1.4"

--- a/go/Gopkg.toml
+++ b/go/Gopkg.toml
@@ -48,3 +48,7 @@
 [[constraint]]
   name = "github.com/sirupsen/logrus"
   version = "1.0.3"
+
+[[constraint]]
+  name = "github.com/Azure/go-autorest"
+  version = "v9.6.0"

--- a/go/porcelain/http/http.go
+++ b/go/porcelain/http/http.go
@@ -1,0 +1,70 @@
+package http
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/go-openapi/runtime"
+)
+
+type RetryableTransport struct {
+	tr       runtime.ClientTransport
+	attempts int
+}
+
+type retryableRoundTripper struct {
+	tr       http.RoundTripper
+	attempts int
+}
+
+func NewRetryableTransport(tr runtime.ClientTransport, attempts int) *RetryableTransport {
+	return &RetryableTransport{
+		tr:       tr,
+		attempts: attempts,
+	}
+}
+
+func (tr *RetryableTransport) Submit(op *runtime.ClientOperation) (interface{}, error) {
+	op.Client.Transport = &retryableRoundTripper{
+		tr:       op.Client.Transport,
+		attempts: tr.attempts,
+	}
+
+	return tr.Submit(op)
+}
+
+func (tr *retryableRoundTripper) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+	rr := autorest.NewRetriableRequest(req)
+
+	// Increment to add the first call (attempts denotes number of retries)
+	tr.attempts++
+	for attempt := 0; attempt < tr.attempts; attempt++ {
+		err = rr.Prepare()
+		if err != nil {
+			return resp, err
+		}
+		resp, err = tr.RoundTrip(rr.Request())
+		if err != nil || resp.StatusCode != http.StatusTooManyRequests {
+			return resp, err
+		}
+		delayWithRateLimit(resp, req.Cancel)
+	}
+	return resp, err
+}
+
+func delayWithRateLimit(resp *http.Response, cancel <-chan struct{}) {
+	retryReset, err := strconv.ParseInt(resp.Header.Get("X-RateLimit-Reset"), 10, 0)
+	if err != nil {
+		return
+	}
+
+	t := time.Unix(retryReset, 0)
+	select {
+	case <-time.After(t.Sub(time.Now())):
+		return
+	case <-cancel:
+		return
+	}
+}

--- a/go/porcelain/http/http_test.go
+++ b/go/porcelain/http/http_test.go
@@ -64,3 +64,81 @@ func TestRetryableTransport(t *testing.T) {
 	actual := res.(string)
 	require.EqualValues(t, "ok", actual)
 }
+
+func TestRetryableTransportExceedsMaxAttempts(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		attempts++
+		reset := fmt.Sprintf("%d", time.Now().Add(1*time.Second).Unix())
+		rw.Header().Set("X-RateLimit-Reset", reset)
+		rw.WriteHeader(http.StatusTooManyRequests)
+		_, _ = rw.Write([]byte("rate limited"))
+	}))
+	defer server.Close()
+
+	rwrtr := runtime.ClientRequestWriterFunc(func(req runtime.ClientRequest, _ strfmt.Registry) error {
+		return nil
+	})
+
+	hu, _ := url.Parse(server.URL)
+	rt := NewRetryableTransport(httptransport.New(hu.Host, "/", []string{"http"}), 2)
+
+	_, err := rt.Submit(&runtime.ClientOperation{
+		ID:          "getSites",
+		Method:      "GET",
+		PathPattern: "/",
+		Params:      rwrtr,
+		Reader: runtime.ClientResponseReaderFunc(func(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
+			if response.Code() == 200 {
+				var result string
+				if err := consumer.Consume(response.Body(), &result); err != nil {
+					return nil, err
+				}
+				return result, nil
+			}
+			return nil, errors.New("Generic error")
+		}),
+	})
+
+	require.Error(t, err)
+	require.Equal(t, 2, attempts)
+}
+
+func TestRetryableWithDifferentError(t *testing.T) {
+	attempts := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		attempts++
+
+		rw.WriteHeader(http.StatusNotFound)
+		_, _ = rw.Write([]byte("not found"))
+	}))
+	defer server.Close()
+
+	rwrtr := runtime.ClientRequestWriterFunc(func(req runtime.ClientRequest, _ strfmt.Registry) error {
+		return nil
+	})
+
+	hu, _ := url.Parse(server.URL)
+	rt := NewRetryableTransport(httptransport.New(hu.Host, "/", []string{"http"}), 2)
+
+	_, err := rt.Submit(&runtime.ClientOperation{
+		ID:          "getSites",
+		Method:      "GET",
+		PathPattern: "/",
+		Params:      rwrtr,
+		Reader: runtime.ClientResponseReaderFunc(func(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
+			if response.Code() == 200 {
+				var result string
+				if err := consumer.Consume(response.Body(), &result); err != nil {
+					return nil, err
+				}
+				return result, nil
+			}
+			return nil, errors.New("Generic error")
+		}),
+	})
+
+	require.Error(t, err)
+	require.Equal(t, 1, attempts)
+}

--- a/go/porcelain/http/http_test.go
+++ b/go/porcelain/http/http_test.go
@@ -1,0 +1,66 @@
+package http
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryableTransport(t *testing.T) {
+	attempts := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		attempts++
+
+		if attempts == 1 {
+			reset := fmt.Sprintf("%d", time.Now().Add(1*time.Second).Unix())
+			rw.Header().Set("X-RateLimit-Reset", reset)
+			rw.WriteHeader(http.StatusTooManyRequests)
+			_, _ = rw.Write([]byte("rate limited"))
+		} else {
+			rw.WriteHeader(http.StatusOK)
+			_, _ = rw.Write([]byte("ok"))
+		}
+	}))
+	defer server.Close()
+
+	rwrtr := runtime.ClientRequestWriterFunc(func(req runtime.ClientRequest, _ strfmt.Registry) error {
+		return nil
+	})
+
+	hu, _ := url.Parse(server.URL)
+	rt := NewRetryableTransport(httptransport.New(hu.Host, "/", []string{"http"}), 2)
+
+	res, err := rt.Submit(&runtime.ClientOperation{
+		ID:          "getSites",
+		Method:      "GET",
+		PathPattern: "/",
+		Params:      rwrtr,
+		Reader: runtime.ClientResponseReaderFunc(func(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
+			if response.Code() == 200 {
+				var result string
+				if err := consumer.Consume(response.Body(), &result); err != nil {
+					return nil, err
+				}
+				return result, nil
+			}
+			return nil, errors.New("Generic error")
+		}),
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 2, attempts)
+
+	require.IsType(t, "", res)
+	actual := res.(string)
+	require.EqualValues(t, "ok", actual)
+}

--- a/go/porcelain/netlify_client.go
+++ b/go/porcelain/netlify_client.go
@@ -2,29 +2,42 @@ package porcelain
 
 import (
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 	"github.com/netlify/open-api/go/plumbing"
+	"github.com/netlify/open-api/go/porcelain/http"
 )
 
 const DefaultSyncFileLimit = 7000
 const DefaultConcurrentUploadLimit = 10
+const DefaultRetryAttempts = 3
 
 // Default netlify HTTP client.
 var Default = NewHTTPClient(nil)
 
 // NewHTTPClient creates a new netlify HTTP client.
 func NewHTTPClient(formats strfmt.Registry) *Netlify {
-	n := plumbing.NewHTTPClient(formats)
-	return &Netlify{
-		Netlify:       n,
-		syncFileLimit: DefaultSyncFileLimit,
-		uploadLimit:   DefaultConcurrentUploadLimit,
-	}
+	return NewRetryableHTTPClient(formats, DefaultRetryAttempts)
 }
 
-// New creates a new netlify client
+// NewRetryableHTTPClient creates a new netlify HTTP client with a number of attempts for rate limits.
+func NewRetryableHTTPClient(formats strfmt.Registry, attempts int) *Netlify {
+	cfg := plumbing.DefaultTransportConfig()
+	transport := httptransport.New(cfg.Host, cfg.BasePath, cfg.Schemes)
+
+	return NewRetryable(transport, formats, attempts)
+}
+
+// New creates a new netlify client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) *Netlify {
-	n := plumbing.New(transport, formats)
+	return NewRetryable(transport, formats, DefaultRetryAttempts)
+}
+
+// NewRetryable creates a new netlify client with a number of attempts for rate limits.
+func NewRetryable(transport runtime.ClientTransport, formats strfmt.Registry, attempts int) *Netlify {
+	tr := http.NewRetryableTransport(transport, attempts)
+
+	n := plumbing.New(tr, formats)
 	return &Netlify{
 		Netlify:       n,
 		syncFileLimit: DefaultSyncFileLimit,

--- a/swagger.yml
+++ b/swagger.yml
@@ -15,6 +15,11 @@ produces:
   - application/json
 schemes:
   - https
+responses:
+  error:
+    description: error
+    schema:
+      $ref: "#/definitions/error"
 host: api.netlify.com
 basePath: /api/v1
 paths:
@@ -37,9 +42,7 @@ paths:
             items:
               $ref: "#/definitions/site"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     post:
       operationId: createSite
       consumes:
@@ -60,9 +63,7 @@ paths:
           schema:
             $ref: "#/definitions/site"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /sites/{site_id}:
     parameters:
       - name: site_id
@@ -77,9 +78,7 @@ paths:
           schema:
             $ref: "#/definitions/site"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     patch:
       operationId: updateSite
       consumes:
@@ -96,18 +95,14 @@ paths:
           schema:
             $ref: "#/definitions/site"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     delete:
       operationId: deleteSite
       responses:
         '204':
           description: Deleted
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /sites/{site_id}/ssl:
     post:
       operationId: provisionSiteTLSCertificate
@@ -134,9 +129,7 @@ paths:
           schema:
             $ref: "#/definitions/sniCertificate"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     get:
       operationId: showSiteTLSCertificate
       parameters:
@@ -150,9 +143,7 @@ paths:
           schema:
             $ref: "#/definitions/sniCertificate"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /sites/{site_id}/forms:
     get:
       operationId: listSiteForms
@@ -169,9 +160,7 @@ paths:
             items:
               $ref: "#/definitions/form"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /sites/{site_id}/submissions:
     get:
       operationId: listSiteSubmissions
@@ -188,9 +177,7 @@ paths:
             items:
               $ref: "#/definitions/submission"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /sites/{site_id}/files:
     get:
       operationId: listSiteFiles
@@ -207,9 +194,7 @@ paths:
             items:
               $ref: "#/definitions/file"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /sites/{site_id}/assets:
     parameters:
       - name: site_id
@@ -226,9 +211,7 @@ paths:
             items:
               $ref: "#/definitions/asset"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     post:
       operationId: createSiteAsset
       parameters:
@@ -254,9 +237,7 @@ paths:
           schema:
             $ref: "#/definitions/assetSignature"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /sites/{site_id}/assets/{asset_id}:
     parameters:
       - name: site_id
@@ -275,9 +256,7 @@ paths:
           schema:
             $ref: "#/definitions/asset"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     put:
       operationId: updateSiteAsset
       parameters:
@@ -291,18 +270,14 @@ paths:
           schema:
             $ref: "#/definitions/asset"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     delete:
       operationId: deleteSiteAsset
       responses:
         '204':
           description: Deleted
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /sites/{site_id}/assets/{asset_id}/public_signature:
     parameters:
       - name: site_id
@@ -321,9 +296,7 @@ paths:
           schema:
             $ref: "#/definitions/assetPublicSignature"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /sites/{site_id}/files/{file_path}:
     get:
       operationId: getSiteFileByPathName
@@ -342,9 +315,7 @@ paths:
           schema:
             $ref: "#/definitions/file"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /sites/{site_id}/snippets:
     parameters:
       - name: site_id
@@ -361,9 +332,7 @@ paths:
             items:
               $ref: "#/definitions/snippet"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     post:
       operationId: createSiteSnippet
       consumes:
@@ -380,9 +349,7 @@ paths:
           schema:
             $ref: "#/definitions/snippet"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /sites/{site_id}/snippets/{snippet_id}:
     parameters:
       - name: site_id
@@ -401,9 +368,7 @@ paths:
           schema:
             $ref: "#/definitions/snippet"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     put:
       operationId: updateSiteSnippet
       consumes:
@@ -418,18 +383,14 @@ paths:
         '204':
           description: No content
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     delete:
       operationId: deleteSiteSnippet
       responses:
         '204':
           description: No content
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /sites/{site_id}/metadata:
     parameters:
       - name: site_id
@@ -444,9 +405,7 @@ paths:
           schema:
             $ref: "#/definitions/metadata"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     put:
       operationId: updateSiteMetadata
       parameters:
@@ -459,9 +418,7 @@ paths:
         '204':
           description: No content
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /sites/{site_id}/build_hooks:
     parameters:
       - name: site_id
@@ -478,9 +435,7 @@ paths:
             items:
               $ref: "#/definitions/buildHook"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     post:
       operationId: createSiteBuildHook
       consumes:
@@ -497,9 +452,7 @@ paths:
           schema:
             $ref: "#/definitions/buildHook"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /sites/{site_id}/build_hooks/{id}:
     parameters:
       - name: site_id
@@ -518,9 +471,7 @@ paths:
           schema:
             $ref: "#/definitions/buildHook"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     put:
       operationId: updateSiteBuildHook
       consumes:
@@ -535,18 +486,14 @@ paths:
         '204':
           description: No content
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     delete:
       operationId: deleteSiteBuildHook
       responses:
         '204':
           description: No content
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /sites/{site_id}/deploys/{deploy_id}:
     get:
       operationId: getSiteDeploy
@@ -565,9 +512,7 @@ paths:
           schema:
             $ref: "#/definitions/deploy"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     put:
       operationId: updateSiteDeploy
       parameters:
@@ -590,9 +535,7 @@ paths:
           schema:
             $ref: "#/definitions/deploy"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /sites/{site_id}/deploys:
     parameters:
       - name: site_id
@@ -609,9 +552,7 @@ paths:
             items:
               $ref: "#/definitions/deploy"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     post:
       operationId: createSiteDeploy
       parameters:
@@ -629,9 +570,7 @@ paths:
           schema:
             $ref: "#/definitions/deploy"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /sites/{site_id}/deploys/{deploy_id}:
     get:
       operationId: getSiteDeploy
@@ -650,9 +589,7 @@ paths:
           schema:
             $ref: "#/definitions/deploy"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     put:
       operationId: updateSiteDeploy
       parameters:
@@ -675,9 +612,7 @@ paths:
           schema:
             $ref: "#/definitions/deploy"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /sites/{site_id}/deploys/{deploy_id}/restore:
     post:
       operationId: restoreSiteDeploy
@@ -696,9 +631,7 @@ paths:
           schema:
             $ref: "#/definitions/deploy"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /sites/{site_id}/builds:
     parameters:
       - name: site_id
@@ -715,9 +648,7 @@ paths:
             items:
               $ref: "#/definitions/build"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /builds/{build_id}:
     parameters:
       - name: build_id
@@ -732,9 +663,7 @@ paths:
           schema:
             $ref: "#/definitions/build"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /builds/{build_id}/log:
     parameters:
       - name: build_id
@@ -752,9 +681,7 @@ paths:
         '204':
           description: No content
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /sites/{site_id}/dns:
     parameters:
       - name: site_id
@@ -771,9 +698,7 @@ paths:
             items:
               $ref: "#/definitions/dnsZone"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     put:
       operationId: configureDNSForSite
       responses:
@@ -784,9 +709,7 @@ paths:
             items:
               $ref: "#/definitions/dnsZone"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /deploys/{deploy_id}:
     get:
       operationId: getDeploy
@@ -801,9 +724,7 @@ paths:
           schema:
             $ref: "#/definitions/deploy"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /deploys/{deploy_id}/lock:
     post:
       operationId: lockDeploy
@@ -818,9 +739,7 @@ paths:
           schema:
             $ref: "#/definitions/deploy"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /deploys/{deploy_id}/unlock:
     post:
       operationId: unlockDeploy
@@ -835,9 +754,7 @@ paths:
           schema:
             $ref: "#/definitions/deploy"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /deploys/{deploy_id}/files/{path}:
     put:
       operationId: uploadDeployFile
@@ -864,9 +781,7 @@ paths:
           schema:
             $ref: "#/definitions/file"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /deploys/{deploy_id}/functions/{name}:
     put:
       operationId: uploadDeployFunction
@@ -893,9 +808,7 @@ paths:
           schema:
             $ref: "#/definitions/function"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /forms:
     get:
       operationId: listForms
@@ -907,9 +820,7 @@ paths:
             items:
               $ref: "#/definitions/form"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /forms/{form_id}/submissions:
     get:
       operationId: listFormSubmissions
@@ -926,9 +837,7 @@ paths:
             items:
               $ref: "#/definitions/submission"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /hooks:
     get:
       operationId: listHooksBySiteId
@@ -945,9 +854,7 @@ paths:
             items:
               $ref: "#/definitions/hook"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     post:
       operationId: createHookBySiteId
       consumes:
@@ -968,9 +875,7 @@ paths:
           schema:
             $ref: "#/definitions/hook"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /hooks/{hook_id}:
     parameters:
       - name: hook_id
@@ -985,9 +890,7 @@ paths:
           schema:
             $ref: "#/definitions/hook"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     put:
       operationId: updateHook
       parameters:
@@ -1002,9 +905,7 @@ paths:
           schema:
             $ref: "#/definitions/hook"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     delete:
       operationId: deleteHookBySiteId
       responses:
@@ -1024,9 +925,7 @@ paths:
           schema:
             $ref: "#/definitions/hook"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /hooks/types:
     get:
       operationId: listHookTypes
@@ -1038,9 +937,7 @@ paths:
             items:
               $ref: "#/definitions/hookType"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /oauth/tickets:
     post:
       operationId: createTicket
@@ -1055,9 +952,7 @@ paths:
           schema:
             $ref: "#/definitions/ticket"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /oauth/tickets/{ticket_id}:
     get:
       operationId: showTicket
@@ -1072,9 +967,7 @@ paths:
           schema:
             $ref: "#/definitions/ticket"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /oauth/tickets/{ticket_id}/exchange:
     post:
       operationId: exchangeTicket
@@ -1089,9 +982,7 @@ paths:
           schema:
             $ref: "#/definitions/accessToken"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /deploy_keys:
     get:
       operationId: listDeployKeys
@@ -1103,9 +994,7 @@ paths:
             items:
               $ref: "#/definitions/deployKey"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     post:
       operationId: createDeployKey
       consumes:
@@ -1116,9 +1005,7 @@ paths:
           schema:
             $ref: "#/definitions/deployKey"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /deploy_keys/{key_id}:
     parameters:
       - name: key_id
@@ -1133,18 +1020,14 @@ paths:
           schema:
             $ref: "#/definitions/deployKey"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     delete:
       operationId: deleteDeployKey
       responses:
         '204':
           description: Not Content
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /{account_slug}/sites:
     get:
       operationId: listSitesForAccount # an account represents a team or a user
@@ -1164,9 +1047,7 @@ paths:
             items:
               $ref: "#/definitions/site"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /{account_slug}/members:
     parameters:
       - name: account_slug
@@ -1183,9 +1064,7 @@ paths:
             items:
               $ref: "#/definitions/member"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     post:
       operationId: addMemberToAccount # an account represents a team or a user
       parameters:
@@ -1205,9 +1084,7 @@ paths:
             items:
               $ref: "#/definitions/member"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /billing/payment_methods:
     get:
       operationId: listPaymentMethodsForUser
@@ -1219,9 +1096,7 @@ paths:
             items:
               $ref: "#/definitions/paymentMethod"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /accounts/types:
     get:
       operationId: listAccountTypesForUser
@@ -1233,9 +1108,7 @@ paths:
             items:
               $ref: "#/definitions/accountType"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /accounts:
     get:
       operationId: listAccountsForUser
@@ -1247,9 +1120,7 @@ paths:
             items:
               $ref: "#/definitions/accountMembership"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     post:
       operationId: createAccount
       parameters:
@@ -1264,9 +1135,7 @@ paths:
           schema:
             $ref: "#/definitions/accountMembership"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /accounts/{account_id}:
     parameters:
       - name: account_id
@@ -1286,18 +1155,14 @@ paths:
           schema:
             $ref: "#/definitions/accountMembership"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
     delete:
       operationId: cancelAccount
       responses:
         '204':
           description: Not Content
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
   /accounts/{account_id}/audit:
     parameters:
       - name: account_id
@@ -1321,9 +1186,7 @@ paths:
             items:
               $ref: "#/definitions/auditLog"
         default:
-          description: error
-          schema:
-            $ref: "#/definitions/error"
+          $ref: "#/responses/error"
 definitions:
     site:
       type: object

--- a/ui/swagger.json
+++ b/ui/swagger.json
@@ -30,10 +30,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -57,10 +54,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -79,10 +73,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -107,10 +98,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -121,10 +109,7 @@
             "description": "Not Content"
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -163,10 +148,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -193,10 +175,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -212,10 +191,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -236,10 +212,7 @@
             "description": "No content"
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -274,10 +247,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -294,10 +264,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -313,10 +280,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -327,10 +291,7 @@
             "description": "Not Content"
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -362,10 +323,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -407,10 +365,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -452,10 +407,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -479,10 +431,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -506,10 +455,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -528,10 +474,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -558,10 +501,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -588,10 +528,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -624,10 +561,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -646,10 +580,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -665,10 +596,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -692,10 +620,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -727,10 +652,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -762,10 +684,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -789,10 +708,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -816,10 +732,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -855,10 +768,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -890,10 +800,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -909,10 +816,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -923,10 +827,7 @@
             "description": "Deleted"
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -953,10 +854,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -983,10 +881,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1026,10 +921,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1053,10 +945,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1078,10 +967,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1092,10 +978,7 @@
             "description": "Deleted"
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1125,10 +1008,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1161,10 +1041,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1191,10 +1068,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1218,10 +1092,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1245,10 +1116,7 @@
             "description": "No content"
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1259,10 +1127,7 @@
             "description": "No content"
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1295,10 +1160,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1325,10 +1187,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1357,10 +1216,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1398,10 +1254,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1437,10 +1290,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -1470,10 +1320,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -1492,10 +1339,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1512,10 +1356,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1550,10 +1391,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -1583,10 +1421,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -1613,10 +1448,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -1632,10 +1464,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1656,10 +1485,7 @@
             "description": "No content"
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1686,10 +1512,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1716,10 +1539,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1743,10 +1563,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1770,10 +1587,7 @@
             "description": "No content"
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1784,10 +1598,7 @@
             "description": "No content"
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1825,10 +1636,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1865,10 +1673,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -1895,10 +1700,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -1917,10 +1719,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1955,10 +1754,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       },
@@ -1998,10 +1794,7 @@
             }
           },
           "default": {
-            "description": "error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
+            "$ref": "#/responses/error"
           }
         }
       }
@@ -3049,6 +2842,14 @@
         "id": {
           "type": "string"
         }
+      }
+    }
+  },
+  "responses": {
+    "error": {
+      "description": "error",
+      "schema": {
+        "$ref": "#/definitions/error"
       }
     }
   },


### PR DESCRIPTION
Add a transport retry logic for rate limited requests. It's configured to try three times before backing off, or cancelling when the request is cancelled.

I've also added new factory functions to modify the number of attempts.

Fixes #58 

Signed-off-by: David Calavera <david.calavera@gmail.com>