### PR TITLE
Upload go binaries as functions

### DIFF
--- a/go/Gopkg.lock
+++ b/go/Gopkg.lock
@@ -122,6 +122,12 @@
   version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/rsc/goversion"
+  packages = ["version"]
+  revision = "b792656d10497b6b61ef55ce8e3bb725965bda2c"
+
+[[projects]]
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   revision = "f006c2ac4710855cf0f916dd6b77acf6b048dc6e"
@@ -172,6 +178,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "37aa9ade4f7ae265a41655eb76daecc45205975d6e80bc9a8412d655c0775f2d"
+  inputs-digest = "1b5d4f5577ed7425dcf1cccfdd1c586cb13e028f5c70be990af241820303942b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/go/Gopkg.toml
+++ b/go/Gopkg.toml
@@ -56,3 +56,7 @@
 [[constraint]]
   name = "github.com/stretchr/testify"
   version = "v1.1.4"
+
+[[constraint]]
+  name = "github.com/rsc/goversion"
+  branch = "master"

--- a/go/plumbing/operations/upload_deploy_function_parameters.go
+++ b/go/plumbing/operations/upload_deploy_function_parameters.go
@@ -69,6 +69,8 @@ type UploadDeployFunctionParams struct {
 	FileBody io.ReadCloser
 	/*Name*/
 	Name string
+	/*Runtime*/
+	Runtime *string
 
 	timeout    time.Duration
 	Context    context.Context
@@ -141,6 +143,17 @@ func (o *UploadDeployFunctionParams) SetName(name string) {
 	o.Name = name
 }
 
+// WithRuntime adds the runtime to the upload deploy function params
+func (o *UploadDeployFunctionParams) WithRuntime(runtime *string) *UploadDeployFunctionParams {
+	o.SetRuntime(runtime)
+	return o
+}
+
+// SetRuntime adds the runtime to the upload deploy function params
+func (o *UploadDeployFunctionParams) SetRuntime(runtime *string) {
+	o.Runtime = runtime
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *UploadDeployFunctionParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -161,6 +174,22 @@ func (o *UploadDeployFunctionParams) WriteToRequest(r runtime.ClientRequest, reg
 	// path param name
 	if err := r.SetPathParam("name", o.Name); err != nil {
 		return err
+	}
+
+	if o.Runtime != nil {
+
+		// query param runtime
+		var qrRuntime string
+		if o.Runtime != nil {
+			qrRuntime = *o.Runtime
+		}
+		qRuntime := qrRuntime
+		if qRuntime != "" {
+			if err := r.SetQueryParam("runtime", qRuntime); err != nil {
+				return err
+			}
+		}
+
 	}
 
 	if len(res) > 0 {

--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -586,7 +586,7 @@ func goFile(filePath string, i os.FileInfo) bool {
 	}
 
 	v, err := version.ReadExe(filePath)
-	return err == nil && strings.HasPrefix(v.Release, "1.")
+	return err == nil && strings.HasPrefix(v.Release, "go1.")
 }
 
 func ignoreFile(rel string) bool {

--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -29,6 +29,8 @@ import (
 
 const (
 	preProcessingTimeout = time.Minute * 5
+	jsRuntime            = "js"
+	goRuntime            = "go"
 )
 
 type uploadType int
@@ -509,13 +511,13 @@ func bundle(functionDir string, observer DeployObserver) (*deployFiles, error) {
 
 		switch {
 		case jsFile(i):
-			file, err := newFunctionFile(filePath, i, "js")
+			file, err := newFunctionFile(filePath, i, jsRuntime, observer)
 			if err != nil {
 				return nil, err
 			}
 			functions.Add(file.Name, file)
 		case goFile(filePath, i):
-			file, err := newFunctionFile(filePath, i, "go")
+			file, err := newFunctionFile(filePath, i, goRuntime, observer)
 			if err != nil {
 				return nil, err
 			}

--- a/swagger.yml
+++ b/swagger.yml
@@ -813,6 +813,9 @@ paths:
           type: string
           in: path
           required: true
+        - name: runtime
+          type: string
+          in: query
         - name: file_body
           in: body
           schema:

--- a/ui/swagger.json
+++ b/ui/swagger.json
@@ -390,6 +390,11 @@
             "required": true
           },
           {
+            "type": "string",
+            "name": "runtime",
+            "in": "query"
+          },
+          {
             "name": "file_body",
             "in": "body",
             "required": true,


### PR DESCRIPTION
With AWSLambda supporting Go, I thought it'd be interesting to
do some exploration to support them.

Go support requires binary files, so we cannot depend on the file
extension to know if what we're uploading is JS or Go. Instead, we can
have a well known path convention to put Go binaries, like
`well-known-go`, and assume that all executables there are Go binaries.

We'd also need a way to tell our API that something should use the go
runtime and not the js runtime. I added a `Runtime` attribute to the file
bundle, so we can configure aws lambda with the right flags.

Signed-off-by: David Calavera <david.calavera@gmail.com>