### PR TITLE
Replace backslashes in file path names.

### DIFF
--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -460,10 +460,11 @@ func walk(dir string, observer DeployObserver) (*deployFiles, error) {
 		}
 
 		if !info.IsDir() && info.Mode().IsRegular() {
-			rel, err := filepath.Rel(dir, path)
+			osRel, err := filepath.Rel(dir, path)
 			if err != nil {
 				return err
 			}
+			rel := forceSlashSeparators(osRel)
 
 			if ignoreFile(rel) {
 				return nil

--- a/go/porcelain/deploy_unix.go
+++ b/go/porcelain/deploy_unix.go
@@ -1,0 +1,6 @@
+// +build !windows
+package porcelain
+
+func forceSlashSeparators(name string) string {
+	return name
+}

--- a/go/porcelain/deploy_windows.go
+++ b/go/porcelain/deploy_windows.go
@@ -1,0 +1,10 @@
+package porcelain
+
+import (
+	"os"
+	"strings"
+)
+
+func forceSlashSeparators(name string) string {
+	return strings.Replace(name, os.PathSeparator, "/", -1)
+}


### PR DESCRIPTION
Fixes issues not deploying files under the right paths using Windows.

Fixes #86

Signed-off-by: David Calavera <david.calavera@gmail.com>