### PR TITLE
Fix the read file issue for asset management

### DIFF
--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -162,6 +162,7 @@ func (n *Netlify) DoDeploy(ctx context.Context, options *DeployOptions, deploy *
 		}
 	}
 
+	context.GetLogger(ctx).Infof("Getting files info with asset management flag: %v", deploy.SiteCapabilities.AssetManagement)
 	files, err := walk(options.Dir, options.Observer, deploy.SiteCapabilities.AssetManagement)
 	if err != nil {
 		if options.Observer != nil {
@@ -489,6 +490,11 @@ func walk(dir string, observer DeployObserver, useAssetManagement bool) (*deploy
 			file.Sum = hex.EncodeToString(s.Sum(nil))
 
 			if useAssetManagement {
+				o, err := os.Open(path)
+				if err != nil {
+					return err
+				}
+				defer o.Close()
 				originalSha := getAssetManagementSha(o)
 				if originalSha != "" {
 					file.Sum += ":" + string(originalSha)


### PR DESCRIPTION
There was a bug around `getAssetManagementSha`. Because I reused the file `o`, the reader was already read with `io.Copy` and there was nothing to read at the point when try to see if it's LFS pointer file or not.
With this PR, we open a file again and read it. Also added some logging. Confirmed that it worked nicely with the flow with buildbot.