### PR TITLE
Save sha without original sha when to save in Hashed

### DIFF
--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -121,8 +121,13 @@ func newDeployFiles() *deployFiles {
 func (d *deployFiles) Add(p string, f *FileBundle) {
 	d.Files[p] = f
 	d.Sums[p] = f.Sum
-	list, _ := d.Hashed[f.Sum]
-	d.Hashed[f.Sum] = append(list, f)
+	// Remove ":original_sha" part when to save in Hashed (asset management)
+	sum := f.Sum
+	if strings.Contains(sum, ":") {
+		sum = strings.Split(sum, ":")[0]
+	}
+	list, _ := d.Hashed[sum]
+	d.Hashed[sum] = append(list, f)
 }
 
 func (n *Netlify) overCommitted(d *deployFiles) bool {

--- a/go/porcelain/deploy_test.go
+++ b/go/porcelain/deploy_test.go
@@ -24,3 +24,30 @@ func TestGetAssetManagementSha(t *testing.T) {
 		}
 	}
 }
+
+func TestAddWithAssetManagement(t *testing.T) {
+	files := newDeployFiles()
+	tests := []struct {
+		rel string
+		sum string
+	}{
+		{"foo.jpg", "sum1"},
+		{"bar.jpg", "sum2"},
+		{"baz.jpg", "sum3:originalsha"},
+	}
+
+	for _, test := range tests {
+		file := &FileBundle{}
+		file.Sum = test.sum
+		files.Add(test.rel, file)
+	}
+
+	out := files.Hashed["sum3"]
+	if len(out) != 1 {
+		t.Fatalf("expected `%d`, got `%d`", 1, len(out))
+	}
+	out2 := files.Sums["baz.jpg"]
+	if out2 != "sum3:originalsha" {
+		t.Fatalf("expected `%v`, got `%v`", "sum3:originalsha", out2)
+	}
+}


### PR DESCRIPTION
open-api will talk to api when to make a new deploy, which is the list of files and shas:

```
{ "index.html": "file_sha", "foo.jpg": "pointer_file_sha:original_file_sha", "bar.html": "file_sha2"}
```

then, api response the following as required (need to upload these shas to api):

```
["file_sha", "pointer_file_sha"]
```

so that open-api knows that it needs to upload files that have these shas (index.html and foo.jpg).

Previously, open-api wasn't able to upload "foo.jpg" because it didn't recognize "pointer_file_sha" is about "foo.jpg". This PR fixes it.