### PR TITLE
Add createSiteBuild endpoint

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -607,6 +607,15 @@ paths:
               $ref: "#/definitions/build"
         default:
           $ref: "#/responses/error"
+    post:
+      operationId: createSiteBuild
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: "#/definitions/build"
+        default:
+          $ref: "#/responses/error"
   /sites/{site_id}/deployed-branches:
     parameters:
       - name: site_id
@@ -1218,7 +1227,7 @@ paths:
               $ref: "#/definitions/auditLog"
         default:
           $ref: "#/responses/error"
- 
+
  # begin submission
   /submissions/{submission_id}:
       parameters:


### PR DESCRIPTION
I'm currently building a netlify menubar client and use [the netlify JS SDK](https://github.com/netlify/js-client). I found out that the swagger api definitions are missing the endpoint definition for a POST to `sites/$sitesId/builds` which is used by the netlify Admin UI to manually trigger builds (which is functionality I'd like to provide in the Netlify menubar app).

I talked to Dennis from support and he told me that the Netlify Admin UI is the source of truth. This PR adds documentation for the endpoint so that it'll be reflected in the JS Sdk and potentially Go SDK. :)