### PR TITLE
Rename asset management to large media (and LFS)

### DIFF
--- a/go/models/deploy_site_capabilities.go
+++ b/go/models/deploy_site_capabilities.go
@@ -15,8 +15,8 @@ import (
 // swagger:model deploySiteCapabilities
 type DeploySiteCapabilities struct {
 
-	// asset management
-	AssetManagement bool `json:"asset_management,omitempty"`
+	// large media
+	LargeMedia bool `json:"large_media,omitempty"`
 }
 
 // Validate validates this deploy site capabilities

--- a/go/porcelain/deploy_test.go
+++ b/go/porcelain/deploy_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestGetAssetManagementSha(t *testing.T) {
+func TestGetLFSSha(t *testing.T) {
 	tests := []struct {
 		contents string
 		length   int
@@ -18,14 +18,14 @@ func TestGetAssetManagementSha(t *testing.T) {
 
 	for _, test := range tests {
 		file := strings.NewReader(test.contents)
-		out := getAssetManagementSha(file)
+		out := getLFSSha(file)
 		if len(out) != test.length {
 			t.Fatalf("expected `%d`, got `%d`", test.length, len(out))
 		}
 	}
 }
 
-func TestAddWithAssetManagement(t *testing.T) {
+func TestAddWithLargeMedia(t *testing.T) {
 	files := newDeployFiles()
 	tests := []struct {
 		rel string

--- a/swagger.yml
+++ b/swagger.yml
@@ -1580,7 +1580,7 @@ definitions:
         site_capabilities:
           type: object
           properties:
-            asset_management:
+            large_media:
               type: boolean
     deployFiles:
       type: object


### PR DESCRIPTION
Simple rename of the site capability from asset management to large media.