### PR TITLE
Add Site's ID domain to the swagger definition.

### DIFF
--- a/go/models/site.go
+++ b/go/models/site.go
@@ -55,6 +55,9 @@ type Site struct {
 	// id
 	ID string `json:"id,omitempty"`
 
+	// id domain
+	IDDomain string `json:"id_domain,omitempty"`
+
 	// managed dns
 	ManagedDNS bool `json:"managed_dns,omitempty"`
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -1362,6 +1362,8 @@ definitions:
                   type: boolean
         build_settings:
           $ref: "#/definitions/repoInfo"
+        id_domain:
+          type: string
     siteSetup:
       allOf:
         - $ref: "#/definitions/site"


### PR DESCRIPTION
This missing property is a hostname guaranteed to never changes.