### PR TITLE
Add API driven configuration parameters

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -1547,6 +1547,11 @@ definitions:
         $ref: "#/definitions/repoInfo"
       id_domain:
         type: string
+      default_hooks_data:
+        type: object
+        properties:
+          access_token:
+            type: string
   siteSetup:
     allOf:
       - $ref: "#/definitions/site"
@@ -1584,6 +1589,8 @@ definitions:
         type: object
         additionalProperties:
           type: string
+      instalation_id:
+        type: string
   submission:
     type: object
     properties:


### PR DESCRIPTION
Documented use in https://github.com/netlify/cli-utils/issues/2#issuecomment-460399753

This adds parameters used by the API to set up default hooks and GitHub Apps integrations.