### PR TITLE
Change large_media to large_media_enabled

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 
 We use [go-swagger](https://github.com/go-swagger/go-swagger) to validate our spec against the 2.0 spec of Open API.
 
-We currently depend on version 0.16.0 of the go swagger toolchain. You can download the binary for your platform from this release page:
+We currently depend on version 0.18.0 of the go swagger toolchain. You can download the binary for your platform from this release page:
 
-https://github.com/go-swagger/go-swagger/releases/tag/0.16.0
+https://github.com/go-swagger/go-swagger/releases/tag/0.18.0
 
 ## Spec validation
 

--- a/go/models/deploy_site_capabilities.go
+++ b/go/models/deploy_site_capabilities.go
@@ -15,8 +15,8 @@ import (
 // swagger:model deploySiteCapabilities
 type DeploySiteCapabilities struct {
 
-	// large media
-	LargeMedia bool `json:"large_media,omitempty"`
+	// large media enabled
+	LargeMediaEnabled bool `json:"large_media_enabled,omitempty"`
 }
 
 // Validate validates this deploy site capabilities

--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -173,8 +173,8 @@ func (n *Netlify) DoDeploy(ctx context.Context, options *DeployOptions, deploy *
 		}
 	}
 
-	context.GetLogger(ctx).Infof("Getting files info with large media flag: %v", deploy.SiteCapabilities.LargeMedia)
-	files, err := walk(options.Dir, options.Observer, deploy.SiteCapabilities.LargeMedia)
+	context.GetLogger(ctx).Infof("Getting files info with large media flag: %v", deploy.SiteCapabilities.LargeMediaEnabled)
+	files, err := walk(options.Dir, options.Observer, deploy.SiteCapabilities.LargeMediaEnabled)
 	if err != nil {
 		if options.Observer != nil {
 			options.Observer.OnFailedWalk()

--- a/swagger.yml
+++ b/swagger.yml
@@ -1780,7 +1780,7 @@ definitions:
       site_capabilities:
         type: object
         properties:
-          large_media:
+          large_media_enabled:
             type: boolean
   deployFiles:
     type: object


### PR DESCRIPTION
This flag needs to be renamed since it's conflicting with the usage capability and causing the build failure. Need to be shipped and used in buildbot to fix this.