### PR TITLE
Change embedded DefaultSyncFileLimit to 500

### DIFF
--- a/go/porcelain/netlify_client.go
+++ b/go/porcelain/netlify_client.go
@@ -8,7 +8,7 @@ import (
 	"github.com/netlify/open-api/go/porcelain/http"
 )
 
-const DefaultSyncFileLimit = 7000
+const DefaultSyncFileLimit = 500
 const DefaultConcurrentUploadLimit = 10
 const DefaultRetryAttempts = 3
 
@@ -55,7 +55,9 @@ type Netlify struct {
 }
 
 func (n *Netlify) SetSyncFileLimit(limit int) {
-	n.syncFileLimit = limit
+	if limit > 0 {
+		n.syncFileLimit = limit
+	}
 }
 
 func (n *Netlify) SetConcurrentUploadLimit(limit int) {


### PR DESCRIPTION
We are also setting this as a default on BitBalloon, but in case anyone uses this elsewhere, they will get the correct default.