### PR TITLE
go-client: Don’t poll deploy after upload

### DIFF
--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -290,7 +290,7 @@ func (n *Netlify) DoDeploy(ctx context.Context, options *DeployOptions, deploy *
 		}
 	}
 
-	return n.WaitForDeployComplete(ctx, deploy, options.DoneProcessingTimeout)
+	return deploy, nil
 }
 
 func (n *Netlify) waitForState(ctx context.Context, d *models.Deploy, timeout time.Duration, states ...string) (*models.Deploy, error) {


### PR DESCRIPTION
We decided we no longer need to poll here.  The reason we were polling was to fail the build prior to cache creation.  

This change, essentially allows for cache creation even if tree operations fail later, which is our fault most likely.