### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/go/porcelain/site.go
+++ b/go/porcelain/site.go
@@ -62,7 +62,7 @@ func (n *Netlify) UpdateSite(ctx context.Context, site *models.SiteSetup) (*mode
 	return resp.Payload, nil
 }
 
-// ConfigureSiteTLS provisions a TLS certificate for a site with a custom domain.
+// ConfigureSiteTLSCertificate provisions a TLS certificate for a site with a custom domain.
 // It uses Let's Encrypt if the certificate is empty.
 func (n *Netlify) ConfigureSiteTLSCertificate(ctx context.Context, siteID string, cert *CustomTLSCertificate) (*models.SniCertificate, error) {
 	authInfo := context.GetAuthInfo(ctx)


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?