### PR TITLE
Fix `installation_id` type

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -1735,7 +1735,7 @@ definitions:
         additionalProperties:
           type: string
       installation_id:
-        type: string
+        type: integer
   submission:
     type: object
     properties:


### PR DESCRIPTION
Was marked as `string`, but api returns `integer`

Closes #162