### PR TITLE
Add terms of service

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -2,6 +2,7 @@ swagger: '2.0'
 info:
   version: 0.11.4
   title: Netlify's API definition
+  termsOfService: https://www.netlify.com/legal/terms-of-use/
 securityDefinitions:
   netlifyAuth:
     type: oauth2


### PR DESCRIPTION
This adds [terms of services](https://swagger.io/specification/#infoObject) for the API.

I used this URL: https://www.netlify.com/legal/terms-of-use/
 
I am not sure if our API has a separate terms of use page.