### PR TITLE
Fix YAML syntax error

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -1510,7 +1510,7 @@ definitions:
   splitTests:
     type: array
     items:
-    $ref: '#/definitions/splitTest'
+      $ref: '#/definitions/splitTest'
   splitTest:
     type: object
     properties:


### PR DESCRIPTION
The current `splitTests` definition is parsed as:

```js
{ 
  type: 'array', 
  items: null, 
  '$ref': '#/definitions/splitTest' 
}
```

Instead of:

```js
{ 
  type: 'array', 
  items: {
    '$ref': '#/definitions/splitTest' 
  } 
}
```
