### PR TITLE
Make npm package size smaller

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "split2": "^3.1.0",
     "swagger-ui": "^3.21.0"
   },
+  "files": [],
   "homepage": "https://github.com/netlify/open-api#readme",
   "keywords": [
     "netlify",

--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
     "split2": "^3.1.0",
     "swagger-ui": "^3.21.0"
   },
-  "files": [
-    "js/**/*"
-  ],
   "homepage": "https://github.com/netlify/open-api#readme",
   "keywords": [
     "netlify",


### PR DESCRIPTION
The `files` field in `package.json` includes files that are not meant to be imported and can be safely replaced by an empty array. This makes the npm package size smaller (`18KB` -> `12KB`)

The only file that is used by importers is the `swagger.json` which is the `main` field of `package.json`. The `main` field is always included by `npm publish`, i.e. does not need to be specified in `files`. 

The other two `js/*.js` files are not meant to be imported since those are build and release tasks. The YAML file is also not meant to be imported, the JSON file should be used instead.