### PR TITLE
Group `require()` statements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,6 @@
     "prettier"
   ],
   "rules": {
-    "node/no-unpublished-require": 0
+    "import/order": [2, { "newlines-between": "always" }]
   }
 }


### PR DESCRIPTION
**- Summary**

This ensures the `require()` statements are grouped: first the core modules, then the node modules, then the local imports. This is much easier to browse code when imports/require are on top of the file and grouped.

The `import/order` ESLint rule is added so that the grouping happens automatically on `eslint --fix`, i.e. we don't need to think about it. This happens on save if your IDE supports (VSCode does). 

This also remove a disabled rule which did not need to be disabled.

**- Description for the changelog**

Group `require()` statements together.