### PR TITLE
only check deploy overcommited if no files are returned directly

### DIFF
--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -257,7 +257,7 @@ func (n *Netlify) DoDeploy(ctx context.Context, options *DeployOptions, deploy *
 		deploy = resp.Payload
 	}
 
-	if (len(deploy.Required) == 0) {
+	if len(deploy.Required) == 0 {
 		if n.overCommitted(options.files) {
 			var err error
 			deploy, err = n.WaitUntilDeployReady(ctx, deploy, options.PreProcessTimeout)

--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -257,14 +257,16 @@ func (n *Netlify) DoDeploy(ctx context.Context, options *DeployOptions, deploy *
 		deploy = resp.Payload
 	}
 
-	if n.overCommitted(options.files) {
-		var err error
-		deploy, err = n.WaitUntilDeployReady(ctx, deploy, options.PreProcessTimeout)
-		if err != nil {
-			if options.Observer != nil {
-				options.Observer.OnFailedDelta(deployFiles)
+	if (len(deploy.Required) == 0) {
+		if n.overCommitted(options.files) {
+			var err error
+			deploy, err = n.WaitUntilDeployReady(ctx, deploy, options.PreProcessTimeout)
+			if err != nil {
+				if options.Observer != nil {
+					options.Observer.OnFailedDelta(deployFiles)
+				}
+				return nil, err
 			}
-			return nil, err
 		}
 	}
 


### PR DESCRIPTION
part of simplifying the logic on the client side, when we have a direct response with the required files 