### PR TITLE
Remove `engines.node`

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,8 +64,5 @@
     "eslint": "eslint --fix \"src/**/*.js\"",
     "prettier": "prettier --write --loglevel warn \"src/**/*.js\" \"*.{js,md,yml,json}\"",
     "unit": "ava"
-  },
-  "engines": {
-    "node": "12"
   }
 }


### PR DESCRIPTION
Fixes #219.

This repository's npm package main file is a JSON file.
Therefore this can be used with any Node.js version and the `engines.node` field is unnecessary.