### PR TITLE
Add stop_builds property to repo info

### DIFF
--- a/go/models/repo_info.go
+++ b/go/models/repo_info.go
@@ -53,6 +53,9 @@ type RepoInfo struct {
 
 	// repo url
 	RepoURL string `json:"repo_url,omitempty"`
+
+	// stop builds
+	StopBuilds bool `json:"stop_builds,omitempty"`
 }
 
 // Validate validates this repo info

--- a/swagger.yml
+++ b/swagger.yml
@@ -1864,6 +1864,8 @@ definitions:
           type: string
       installation_id:
         type: integer
+      stop_builds:
+        type: boolean
   submission:
     type: object
     properties:


### PR DESCRIPTION
Add stop_builds property to repo info.
This is a property to configure the stopping builds for the site, see the following doc for more detail:
https://docs.netlify.com/configure-builds/stop-or-activate-builds/