### PR TITLE
Fix race in RetryableTransport

### DIFF
--- a/go/porcelain/http/http.go
+++ b/go/porcelain/http/http.go
@@ -31,10 +31,11 @@ func NewRetryableTransport(tr runtime.ClientTransport, attempts int) *RetryableT
 }
 
 func (t *RetryableTransport) Submit(op *runtime.ClientOperation) (interface{}, error) {
-	client := op.Client
-
-	if client == nil {
-		client = http.DefaultClient
+	client := &http.Client{}
+	if op.Client == nil {
+		*client = *http.DefaultClient
+	} else {
+		*client = *op.Client
 	}
 
 	transport := client.Transport
@@ -47,11 +48,7 @@ func (t *RetryableTransport) Submit(op *runtime.ClientOperation) (interface{}, e
 	}
 
 	op.Client = client
-
 	res, err := t.tr.Submit(op)
-
-	// restore original transport
-	op.Client.Transport = transport
 
 	return res, err
 }

--- a/go/porcelain/http/http.go
+++ b/go/porcelain/http/http.go
@@ -31,11 +31,11 @@ func NewRetryableTransport(tr runtime.ClientTransport, attempts int) *RetryableT
 }
 
 func (t *RetryableTransport) Submit(op *runtime.ClientOperation) (interface{}, error) {
-	client := &http.Client{}
+	var client http.Client
 	if op.Client == nil {
-		*client = *http.DefaultClient
+		client = *http.DefaultClient
 	} else {
-		*client = *op.Client
+		client = *op.Client
 	}
 
 	transport := client.Transport
@@ -47,7 +47,7 @@ func (t *RetryableTransport) Submit(op *runtime.ClientOperation) (interface{}, e
 		attempts: t.attempts,
 	}
 
-	op.Client = client
+	op.Client = &client
 	res, err := t.tr.Submit(op)
 
 	return res, err


### PR DESCRIPTION
There's a race in our `RetryableTransport` because the submit method writes to an `http.Client` referenced by a pointer.

`uploadFile` is called concurrently here, which causes concurrent calls to `RetryableTransport.Submit`.
https://github.com/netlify/open-api/blob/29814e0eeb7075208b4bccdc16dea7da58fbc14c/go/porcelain/deploy.go#L372

I'm a bit uncertain about how the OpenApi runtime works. The `RetryableTransport` has an `http.RoundTripper` on it, but the `Submit` method also also takes an `op` with it's own `Client`. I'm not really sure which one is used when. Open to another solution if someone knows this package well.

This PR resolves the race by copying `op.Client` rather than setting a new `Transport` on it directly.

It also adds a test to call this method concurrently so that it can be picked up by the race detector. We've been getting panics in Buildbot and I think this may be the reason.