### PR TITLE
Use service as a returned object for showService

### DIFF
--- a/go/plumbing/operations/show_service_responses.go
+++ b/go/plumbing/operations/show_service_responses.go
@@ -51,20 +51,20 @@ func NewShowServiceOK() *ShowServiceOK {
 services
 */
 type ShowServiceOK struct {
-	Payload *models.ServiceInstance
+	Payload *models.Service
 }
 
 func (o *ShowServiceOK) Error() string {
 	return fmt.Sprintf("[GET /services/{addonName}][%d] showServiceOK  %+v", 200, o.Payload)
 }
 
-func (o *ShowServiceOK) GetPayload() *models.ServiceInstance {
+func (o *ShowServiceOK) GetPayload() *models.Service {
 	return o.Payload
 }
 
 func (o *ShowServiceOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	o.Payload = new(models.ServiceInstance)
+	o.Payload = new(models.Service)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {

--- a/swagger.yml
+++ b/swagger.yml
@@ -1573,7 +1573,7 @@ paths:
           description: services
           schema:
             type: object
-            $ref: '#/definitions/serviceInstance'
+            $ref: '#/definitions/service'
         default:
           $ref: '#/responses/error'
 


### PR DESCRIPTION
It's a small bug, noticed while reviewing https://github.com/netlify/cli/pull/1344

Looks like this one is not currently used for any Netlify owned client (js-client, go client, CLI, etc.).
It's always nice to fix the bug whenever we notice!