### PR TITLE
adding refresh_token endpoint

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -2571,6 +2571,8 @@ definitions:
         type: string
       access_token:
         type: string
+      refresh_token:
+        type: string
       user_id:
         type: string
       user_email:

--- a/swagger.yml
+++ b/swagger.yml
@@ -1124,6 +1124,26 @@ paths:
               $ref: '#/definitions/hookType'
         default:
           $ref: '#/responses/error'
+  /oauth/token?grant_type=refresh_token:
+    post:
+      operationId: refreshToken
+      tags: [accessToken]
+      parameters:
+        - name: refresh_token
+          type: string
+          in: query
+          required: true
+        - name: client_id
+          type: string
+          in: query
+          required: true
+      responses:
+        '200':
+          description: ok
+          schema:
+            $ref: '#/definitions/accessToken'
+        default:
+          $ref: '#/responses/error'
   /oauth/tickets:
     post:
       operationId: createTicket


### PR DESCRIPTION
#### Description:
Not exactly sure what I am doing here but I believe this will expose the `refresh_token` endpoint thru the open-api spec, making it available to the `js-client` (and I will also regenerate the go client before merging this, as is the protocol I think)

#### Impact:
This could cause downstream issues I think, but is unlikely since it is passing `make validate`, but I am looking for input on that

#### Testing:
Im not sure how to test the client updates for these changes.
passing `make validate`

```
% make validate
GO111MODULE=off go get -u github.com/myitcv/gobin && go mod download
gobin -m -run github.com/go-swagger/go-swagger/cmd/swagger@v0.23.0 validate swagger.yml
2020/10/19 15:50:20
The swagger spec at "swagger.yml" is valid against swagger specification 2.0
```
