### PR TITLE
Remove listForms endpoint

### DIFF
--- a/go/plumbing/operations/operations_client.go
+++ b/go/plumbing/operations/operations_client.go
@@ -153,8 +153,6 @@ type ClientService interface {
 
 	ListFormSubmissions(params *ListFormSubmissionsParams, authInfo runtime.ClientAuthInfoWriter) (*ListFormSubmissionsOK, error)
 
-	ListForms(params *ListFormsParams, authInfo runtime.ClientAuthInfoWriter) (*ListFormsOK, error)
-
 	ListHookTypes(params *ListHookTypesParams, authInfo runtime.ClientAuthInfoWriter) (*ListHookTypesOK, error)
 
 	ListHooksBySiteID(params *ListHooksBySiteIDParams, authInfo runtime.ClientAuthInfoWriter) (*ListHooksBySiteIDOK, error)
@@ -2382,40 +2380,6 @@ func (a *Client) ListFormSubmissions(params *ListFormSubmissionsParams, authInfo
 	}
 	// unexpected success response
 	unexpectedSuccess := result.(*ListFormSubmissionsDefault)
-	return nil, runtime.NewAPIError("unexpected success response: content available as default response in error", unexpectedSuccess, unexpectedSuccess.Code())
-}
-
-/*
-  ListForms list forms API
-*/
-func (a *Client) ListForms(params *ListFormsParams, authInfo runtime.ClientAuthInfoWriter) (*ListFormsOK, error) {
-	// TODO: Validate the params before sending
-	if params == nil {
-		params = NewListFormsParams()
-	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
-		ID:                 "listForms",
-		Method:             "GET",
-		PathPattern:        "/forms",
-		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json"},
-		Schemes:            []string{"https"},
-		Params:             params,
-		Reader:             &ListFormsReader{formats: a.formats},
-		AuthInfo:           authInfo,
-		Context:            params.Context,
-		Client:             params.HTTPClient,
-	})
-	if err != nil {
-		return nil, err
-	}
-	success, ok := result.(*ListFormsOK)
-	if ok {
-		return success, nil
-	}
-	// unexpected success response
-	unexpectedSuccess := result.(*ListFormsDefault)
 	return nil, runtime.NewAPIError("unexpected success response: content available as default response in error", unexpectedSuccess, unexpectedSuccess.Code())
 }
 

--- a/go/porcelain/forms.go
+++ b/go/porcelain/forms.go
@@ -9,7 +9,7 @@ import (
 // ListFormsBySiteId lists the forms of a particular site
 func (n *Netlify) ListFormsBySiteId(ctx context.Context, siteID string) ([]*models.Form, error) {
 	authInfo := context.GetAuthInfo(ctx)
-	resp, err := n.Netlify.Operations.ListSiteForms(operations.NewListSiteFormsParams().WithSiteID(&siteID), authInfo)
+	resp, err := n.Netlify.Operations.ListSiteForms(operations.NewListSiteFormsParams().WithSiteID(siteID), authInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/go/porcelain/forms.go
+++ b/go/porcelain/forms.go
@@ -6,20 +6,10 @@ import (
 	"github.com/netlify/open-api/go/porcelain/context"
 )
 
-// ListForms lists the forms a user has access to.
-func (n *Netlify) ListForms(ctx context.Context, params *operations.ListFormsParams) ([]*models.Form, error) {
-	resp, err := n.Netlify.Operations.ListForms(params, context.GetAuthInfo(ctx))
-	if err != nil {
-		return nil, err
-	}
-
-	return resp.Payload, nil
-}
-
 // ListFormsBySiteId lists the forms of a particular site
 func (n *Netlify) ListFormsBySiteId(ctx context.Context, siteID string) ([]*models.Form, error) {
 	authInfo := context.GetAuthInfo(ctx)
-	resp, err := n.Netlify.Operations.ListForms(operations.NewListFormsParams().WithSiteID(&siteID), authInfo)
+	resp, err := n.Netlify.Operations.ListSiteForms(operations.NewListSiteFormsParams().WithSiteID(&siteID), authInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/go/porcelain/forms_test.go
+++ b/go/porcelain/forms_test.go
@@ -1,0 +1,38 @@
+package porcelain
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/go-openapi/runtime"
+	apiClient "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
+	apiContext "github.com/netlify/open-api/go/porcelain/context"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListFormsBySiteId(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("Content-Type", "application/json; charset=utf-8")
+		rw.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	httpClient := http.DefaultClient
+
+	authInfo := runtime.ClientAuthInfoWriterFunc(func(r runtime.ClientRequest, _ strfmt.Registry) error {
+		r.SetHeaderParam("User-Agent", "buildbot")
+		r.SetHeaderParam("Authorization", "Bearer 1234")
+		return nil
+	})
+
+	parsedURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	tr := apiClient.NewWithClient(parsedURL.Host, "/api/v1", []string{"http"}, httpClient)
+	client := NewRetryable(tr, strfmt.Default, 1)
+	_, err = client.ListFormsBySiteId(apiContext.WithAuthInfo(context.Background(), authInfo), "123")
+	require.NoError(t, err)
+}

--- a/go/porcelain/forms_test.go
+++ b/go/porcelain/forms_test.go
@@ -11,13 +11,26 @@ import (
 	apiClient "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 	apiContext "github.com/netlify/open-api/go/porcelain/context"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestListFormsBySiteId(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.Header().Set("Content-Type", "application/json; charset=utf-8")
-		rw.Write([]byte(`[]`))
+		rw.Write([]byte(`
+			[
+				{
+					"id": "1",
+					"site_id": "123",
+					"name": "contact",
+					"paths": [],
+					"submission_count": 0,
+					"fields": [],
+					"created_at": ""
+				}
+			]`))
+		assert.Equal(t, "/api/v1/sites/123/forms", req.URL.String())
 	}))
 	defer server.Close()
 
@@ -33,6 +46,7 @@ func TestListFormsBySiteId(t *testing.T) {
 	require.NoError(t, err)
 	tr := apiClient.NewWithClient(parsedURL.Host, "/api/v1", []string{"http"}, httpClient)
 	client := NewRetryable(tr, strfmt.Default, 1)
-	_, err = client.ListFormsBySiteId(apiContext.WithAuthInfo(context.Background(), authInfo), "123")
+	forms, err := client.ListFormsBySiteId(apiContext.WithAuthInfo(context.Background(), authInfo), "123")
 	require.NoError(t, err)
+	assert.Equal(t, len(forms), 1)
 }

--- a/swagger.yml
+++ b/swagger.yml
@@ -982,24 +982,6 @@ paths:
             $ref: '#/definitions/pluginRun'
         default:
           $ref: '#/responses/error'
-  /forms:
-    get:
-      operationId: listForms
-      deprecated: true
-      tags: [form]
-      parameters:
-        - name: site_id
-          in: query
-          type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            type: array
-            items:
-              $ref: '#/definitions/form'
-        default:
-          $ref: '#/responses/error'
   /forms/{form_id}/submissions:
     get:
       operationId: listFormSubmissions


### PR DESCRIPTION
This PR removes the deperecated listForms API endpoint from swagger.yml and regenerates the Go client.


### Relevant links
https://github.com/netlify/bitballoon/issues/7814