### PR TITLE
Bump setup-go github action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go ${{ matrix.go }}
-        uses: actions/setup-go@v2-beta
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: ${{ matrix.go_version }}
       - name: Checkout code


### PR DESCRIPTION
Should fix this build failure https://github.com/netlify/open-api/pull/269/checks?check_run_id=1487094976 since the previous version was using The `set-env` command which was deprecated.