### PR TITLE
Remove broken screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ The spec is published and versioned for various ecosystems:
 
 You can view the definition using [Swagger UI](https://swagger.io/tools/swagger-ui/) by visiting [open-api.netlify.com](http://open-api.netlify.com) which provides limited interaction with the API from the browser.
 
-[![screenshot of netlify swagger ui](ui/screenshot.png)](https://open-api.netlify.com)
-
 ### Go Client
 
 [![GoDoc][godoc-img]][godoc]


### PR DESCRIPTION
This was removed when changing to the new layout.
See https://github.com/netlify/open-api/commit/0c6eacfede2b20d0cdc84ec71a2a6fdd81c1c534

Removing screenshot in README instead of updating, as it's easier to
keep up to date.

Close https://github.com/netlify/open-api/issues/254