### PR TITLE
chore: add release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,16 @@
+name: release-please
+on:
+  push:
+    branches:
+      - test/release-flow
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v2
+        id: release
+        with:
+          token: ${{ secrets.NODE_PKG_RELEASE_TOKEN }}
+          release-type: node
+          package-name: '@netlify/open-api'
+        if: ${{ !steps.release.outputs.release_created }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: GoogleCloudPlatform/release-please-action@v2
         id: release
         with:
-          token: ${{ secrets.NODE_PKG_RELEASE_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           release-type: node
           package-name: '@netlify/open-api'
         if: ${{ !steps.release.outputs.release_created }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,7 @@ name: release-please
 on:
   push:
     branches:
-      - test/release-flow
+      - master
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -10,7 +10,8 @@ jobs:
       - uses: GoogleCloudPlatform/release-please-action@v2
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # We can't rely on the GITHUB_TOKEN as we need to trigger
+          # further actions and the GITHUB_TOKEN doesn't allow it
+          token: ${{ secrets.NODE_PKG_RELEASE_TOKEN }}
           release-type: node
           package-name: '@netlify/open-api'
-        if: ${{ !steps.release.outputs.release_created }}

--- a/.github/workflows/swagger-bump.yml
+++ b/.github/workflows/swagger-bump.yml
@@ -1,5 +1,6 @@
 name: swagger-bump
 on:
+  # Workaround for bumping the swagger.yml file on release-please PRs
   push:
     branches:
       - release-*
@@ -16,4 +17,4 @@ jobs:
       - run: npm version:1-swagger
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: "Bump swagger.yml file"
+          commit_message: "chore: bump swagger.yml file"

--- a/.github/workflows/swagger-bump.yml
+++ b/.github/workflows/swagger-bump.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           node-version: 12
           registry-url: 'https://registry.npmjs.org'
-      - run: npm install
+      - run: npm ci
       - run: npm version:1-swagger
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/swagger-bump.yml
+++ b/.github/workflows/swagger-bump.yml
@@ -1,0 +1,19 @@
+name: swagger-bump
+on:
+  push:
+    branches:
+      - release-*
+jobs:
+  swagger-bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - run: npm version:1-swagger
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "Bump swagger.yml file"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,17 +32,17 @@ You may first want to edit swagger.yml to add your field or endpoint definitions
 
 ## Making PRs
 
-1. Don't bump the version number for `swagger.yml` changes. Do that during the release process.
+1. Don't bump the version number for `swagger.yml` changes. The release process handles that.
 2. Ensure `make validate` passes.
 3. The go tests run against the last generated go client. These must pass before making a release.
 4. If all you want is a new endpoint, you can PR just the `swagger.yml` changes for review and regenerate the go client when its ready to go in.
 
 ## Making a new release
 
-1. Make sure you are on the HEAD of the master branch.
-2. regenarate go client (if you haven't) (Make all and commit the results)
-3. bump a JS package version with `npm version [major|minor|patch]` (updates package.json, swagger.yaml and create a git tag)
-4. Run `npm publish` which will as `git push && git push --tags` to push to the origin, create a github release and publish the spec to npm.
+1. Merge the release PR (auto generated via `release-please`).
+2. Switch to the default branch git checkout master.
+3. Pull latest changes git pull.
+4. Run `npm publish`.
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,11 @@ You may first want to edit swagger.yml to add your field or endpoint definitions
 
 ## Making PRs
 
-1. Don't bump the version number for `swagger.yml` changes. The release process handles that.
-2. Ensure `make validate` passes.
-3. The go tests run against the last generated go client. These must pass before making a release.
-4. If all you want is a new endpoint, you can PR just the `swagger.yml` changes for review and regenerate the go client when its ready to go in.
+1. Make sure your PR title and commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec.
+2. Don't bump the version number for `swagger.yml` changes. The release process handles that.
+3. Ensure `make validate` passes.
+4. The go tests run against the last generated go client. These must pass before making a release.
+5. If all you want is a new endpoint, you can PR just the `swagger.yml` changes for review and regenerate the go client when its ready to go in.
 
 ## Making a new release
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -753,42 +753,6 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
-    "auto-changelog": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/auto-changelog/-/auto-changelog-1.16.1.tgz",
-      "integrity": "sha512-1OMUN5UWWhKtlEMpGUfbLFcZHDf4IXMNU4SsGs44xTlSBhjgTOx9ukbahoC7hTqIm6+sRAnlAbLY4UjbDZY18A==",
-      "dev": true,
-      "requires": {
-        "commander": "^3.0.1",
-        "core-js": "^3.2.1",
-        "handlebars": "^4.1.2",
-        "lodash.uniqby": "^4.7.0",
-        "node-fetch": "^2.6.0",
-        "parse-github-url": "^1.0.2",
-        "regenerator-runtime": "^0.13.3",
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
-          "integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==",
-          "dev": true
-        },
-        "regenerator-runtime": {
-          "version": "0.13.3",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
-      }
-    },
     "ava": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ava/-/ava-2.4.0.tgz",
@@ -2104,12 +2068,6 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
-    },
-    "commander": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.1.tgz",
-      "integrity": "sha512-UNgvDd+csKdc9GD4zjtkHKQbT8Aspt2jCBqNSPp53vAS0L1tS9sXB2TCEOPHJ7kt9bN/niWkYj8T3RQSoMXdSQ==",
-      "dev": true
     },
     "common-path-prefix": {
       "version": "1.0.0",
@@ -4705,12 +4663,6 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
-    "lodash.uniqby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
-      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
-      "dev": true
-    },
     "log-symbols": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -5110,12 +5062,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
-    },
-    "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "dev": true
     },
     "node-fetch-h2": {
@@ -5671,12 +5617,6 @@
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
       }
-    },
-    "parse-github-url": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
-      "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==",
-      "dev": true
     },
     "parse-json": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "devDependencies": {
     "analytics": "^0.2.0",
     "analytics-plugin-ga": "^0.1.5",
-    "auto-changelog": "^1.16.1",
     "ava": "^2.4.0",
     "cp-file": "^7.0.0",
     "eslint": "^6.3.0",
@@ -58,8 +57,7 @@
     "convert": "node src/convert.js",
     "version": "run-s version:*",
     "version:1-swagger": "node src/bump-swagger.js",
-    "version:2-changelog": "auto-changelog -p --template keepachangelog --breaking-pattern breaking",
-    "version:3-git": "git add CHANGELOG.md swagger.yml",
+    "version:2-git": "git add swagger.yml",
     "redoc": "node src/docs/build.js",
     "lint": "run-s eslint prettier",
     "eslint": "eslint --fix \"src/**/*.js\"",


### PR DESCRIPTION
This PR partially addresses #285. The idea is to provide a way to tag, release and bump the versions of both `package.json` and `swagger.yml` files. I tried running some tests on this repo but unfortunately seems like `release-please` will always create PRs against the mainline. As such I've ran some tests yesterday on a small repo - https://github.com/JGAntunes/actions-playground/pull/1 - testing `auto-commit`. The idea here is to rely on it as a workaround to bump the `swagger.yml` file based on `package.json` version (which is initially done by `release-please`).

For this to work I'll need to add a secret to the repo (currently don't have access, maybe you can help me witht it @erezrokah?), similar to what we've done, maybe we can use`netlify-bot`s access token? - https://github.com/netlify/cli/pull/1778#issue-558154582