### PR TITLE
fix(package.json): remove scripts no longer required and don't npm ci on swagger bump

### DIFF
--- a/.github/workflows/swagger-bump.yml
+++ b/.github/workflows/swagger-bump.yml
@@ -13,8 +13,7 @@ jobs:
         with:
           node-version: 12
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
-      - run: npm version:1-swagger
+      - run: npm run bump-swagger
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "chore: bump swagger.yml file"

--- a/package.json
+++ b/package.json
@@ -49,15 +49,12 @@
     "url": "git+https://github.com/netlify/open-api.git"
   },
   "scripts": {
-    "prepublishOnly": "git push && git push --tags && gh-release",
     "prepare": "run-s test",
     "test": "run-s lint build unit",
     "start": "run-s lint build",
     "build": "run-s convert redoc",
     "convert": "node src/convert.js",
-    "version": "run-s version:*",
-    "version:1-swagger": "node src/bump-swagger.js",
-    "version:2-git": "git add swagger.yml",
+    "bump-swagger": "node src/bump-swagger.js",
     "redoc": "node src/docs/build.js",
     "lint": "run-s eslint prettier",
     "eslint": "eslint --fix \"src/**/*.js\"",


### PR DESCRIPTION
Currently the [release fails](https://github.com/netlify/open-api/runs/1741730586?check_suite_focus=true) because as part of `npm install/ci` we [run our tests](https://github.com/netlify/open-api/compare/fix/npm-scripts?expand=1#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L53) which validate that the versions of the `package.json`  and `swagger.yml` match. I've just realised the `swagger-bump.js` has no external dependencies whatsoever, so running `npm install` isn't required. The alternative would be to drop that specific test from the `prepare` script which I'm not really comfortable with, given it forces us to run the tests before running `npm publish` which we still need to do locally.

It also removes the `prepublishOnly` script as well as the `version:*` scripts which are no longer required.

This should be enough for #289 to go through 🤞 