### PR TITLE
chore(actions): check uncomitted go source code changes

### DIFF
--- a/.github/workflows/verify-go-src.yml
+++ b/.github/workflows/verify-go-src.yml
@@ -1,0 +1,33 @@
+name: Verify Go client
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  verify-go:
+    name: Verify go client source code is up to date
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        go_version: [1.14.x]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install Go ${{ matrix.go }}
+        uses: actions/setup-go@v2.1.3
+        with:
+          go-version: ${{ matrix.go_version }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: make all
+      - name: Check for changes
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No changes to the go client source files detected"
+          else
+            echo "Changes to the go client source files detected, please run 'make all' and push your changes"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ yarn.lock
 dist
 .vscode
 .gobincache
+swagger_flat.json
+swagger_go.json


### PR DESCRIPTION
This picks up on what has been discussed on #285 and adds a step to verify that the go client is up to date and the files have been checked in (once again based on work @erezrokah did in the CLI 🙏 ). I've tested it in this PR by making some changes to  `swagger.yml` file and not generating a new client - https://github.com/netlify/open-api/runs/1742899676?check_suite_focus=true. - seems solid 😄

I've also added two files to the `.gitignore`, which I believe are only used as [helpers when generating the go glient](https://github.com/netlify/open-api/blob/master/generate.go#L4) and don't need to be checked in. Do tell me if that is not the case though.