### PR TITLE
Ignore cache directories in root of build directory when deploying

### DIFF
--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -500,9 +500,11 @@ func (n *Netlify) uploadFile(ctx context.Context, d *models.Deploy, f *FileBundl
 	}
 }
 
+var getwd = os.Getwd
+
 func walk(dir string, observer DeployObserver, useLargeMedia bool) (*deployFiles, error) {
 	files := newDeployFiles()
-	cwd, err := os.Getwd()
+	cwd, err := getwd()
 	if err != nil {
 		return nil, err
 	}

--- a/go/porcelain/deploy_test.go
+++ b/go/porcelain/deploy_test.go
@@ -150,23 +150,17 @@ func TestWalk_IgnoreNodeModulesInRoot(t *testing.T) {
 	err = ioutil.WriteFile(filepath.Join(dir, "more", "node_modules", "inner-package"), []byte{}, 0644)
 	require.Nil(t, err)
 
+	// When deploy directory != build directory, always deploy node_modules.
+	getwd = func() (string, error) { return "elsewhere", nil }
 	files, err := walk(dir, mockObserver{}, false)
 	require.Nil(t, err)
-
-	// When deploy directory != build directory, always deploy node_modules.
 	assert.NotNil(t, files.Files["node_modules/root-package"])
 	assert.NotNil(t, files.Files["more/node_modules/inner-package"])
 
-	cwd, err := os.Getwd()
-	require.Nil(t, err)
-	err = os.Chdir(dir)
-	require.Nil(t, err)
-	defer os.Chdir(cwd)
-
+	// When deploy directory == build directory, ignore node_modules in deploy directory root.
+	getwd = func() (string, error) { return dir, nil }
 	files, err = walk(dir, mockObserver{}, false)
 	require.Nil(t, err)
-
-	// When deploy directory == build directory, ignore node_modules in deploy directory root.
 	assert.Nil(t, files.Files["node_modules/root-package"])
 	assert.NotNil(t, files.Files["more/node_modules/inner-package"])
 }

--- a/go/porcelain/deploy_test.go
+++ b/go/porcelain/deploy_test.go
@@ -150,16 +150,13 @@ func TestWalk_IgnoreNodeModulesInRoot(t *testing.T) {
 	err = ioutil.WriteFile(filepath.Join(dir, "more", "node_modules", "inner-package"), []byte{}, 0644)
 	require.Nil(t, err)
 
-	// When deploy directory != build directory, always deploy node_modules.
-	getwd = func() (string, error) { return "elsewhere", nil }
-	files, err := walk(dir, mockObserver{}, false)
+	files, err := walk(dir, mockObserver{}, false, false)
 	require.Nil(t, err)
 	assert.NotNil(t, files.Files["node_modules/root-package"])
 	assert.NotNil(t, files.Files["more/node_modules/inner-package"])
 
 	// When deploy directory == build directory, ignore node_modules in deploy directory root.
-	getwd = func() (string, error) { return dir, nil }
-	files, err = walk(dir, mockObserver{}, false)
+	files, err = walk(dir, mockObserver{}, false, true)
 	require.Nil(t, err)
 	assert.Nil(t, files.Files["node_modules/root-package"])
 	assert.NotNil(t, files.Files["more/node_modules/inner-package"])


### PR DESCRIPTION
Fixes https://github.com/netlify/buildbot/issues/1131

Previously, we were moving directories like `node_modules` to the cache after the build was finished but before deploying, so they weren't present at deploy time.

With build plugin steps that run after the site is live, we need to keep these directories around longer. This ignores them from the build directory root during deploy to maintain existing behavior.