### PR TITLE
feat!: support flexible cancelation while awaiting deploy state

### DIFF
--- a/go/porcelain/context/context.go
+++ b/go/porcelain/context/context.go
@@ -3,8 +3,8 @@ package context
 import (
 	"context"
 
-	"github.com/sirupsen/logrus"
 	"github.com/go-openapi/runtime"
+	"github.com/sirupsen/logrus"
 )
 
 type Context interface {

--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bufio"
 	"bytes"
+	gocontext "context"
 	"crypto/sha1"
 	"crypto/sha256"
 	"debug/elf"
@@ -273,7 +274,13 @@ func (n *Netlify) DoDeploy(ctx context.Context, options *DeployOptions, deploy *
 
 	if n.overCommitted(options.files) {
 		var err error
-		deploy, err = n.WaitUntilDeployReady(ctx, deploy, options.PreProcessTimeout)
+
+		timeout := options.PreProcessTimeout
+		if timeout <= 0 {
+			timeout = preProcessingTimeout
+		}
+		deployReadyCtx, _ := gocontext.WithTimeout(ctx, timeout)
+		deploy, err = n.WaitUntilDeployReady(deployReadyCtx, deploy)
 		if err != nil {
 			if options.Observer != nil {
 				options.Observer.OnFailedDelta(deployFiles)
@@ -305,58 +312,48 @@ func (n *Netlify) DoDeploy(ctx context.Context, options *DeployOptions, deploy *
 	return deploy, nil
 }
 
-func (n *Netlify) waitForState(ctx context.Context, d *models.Deploy, timeout time.Duration, states ...string) (*models.Deploy, error) {
+func (n *Netlify) waitForState(ctx context.Context, d *models.Deploy, states ...string) (*models.Deploy, error) {
 	authInfo := context.GetAuthInfo(ctx)
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
 
 	params := operations.NewGetSiteDeployParams().WithSiteID(d.SiteID).WithDeployID(d.ID)
-	start := time.Now()
-	for t := range ticker.C {
-		resp, err := n.Operations.GetSiteDeploy(params, authInfo)
-		if err != nil {
-			time.Sleep(3 * time.Second)
-			continue
-		}
-		context.GetLogger(ctx).WithFields(logrus.Fields{
-			"deploy_id": d.ID,
-			"state":     resp.Payload.State,
-		}).Debugf("Waiting until deploy state in %s", states)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("timed out while waiting to enter states [%s]", strings.Join(states, ", "))
+		case <-ticker.C:
+			resp, err := n.Operations.GetSiteDeploy(params, authInfo)
+			if err != nil {
+				time.Sleep(3 * time.Second)
+				continue
+			}
+			context.GetLogger(ctx).WithFields(logrus.Fields{
+				"deploy_id": d.ID,
+				"state":     resp.Payload.State,
+			}).Debugf("Waiting until deploy state in %s", states)
 
-		for _, state := range states {
-			if resp.Payload.State == state {
-				return resp.Payload, nil
+			for _, state := range states {
+				if resp.Payload.State == state {
+					return resp.Payload, nil
+				}
+			}
+
+			if resp.Payload.State == "error" {
+				return nil, fmt.Errorf("entered error state while waiting to enter states [%s]", strings.Join(states, ", "))
 			}
 		}
-
-		if resp.Payload.State == "error" {
-			return nil, fmt.Errorf("Error: entered error state while waiting to enter states: %s", strings.Join(states, ", "))
-		}
-
-		if t.Sub(start) > timeout {
-			return nil, fmt.Errorf("Error: deploy timed out while waiting to enter states: %s", strings.Join(states, ", "))
-		}
 	}
-
-	return d, nil
 }
 
 // WaitUntilDeployReady blocks until the deploy is in the "prepared" or "ready" state.
-func (n *Netlify) WaitUntilDeployReady(ctx context.Context, d *models.Deploy, timeout time.Duration) (*models.Deploy, error) {
-	if timeout <= 0 {
-		timeout = preProcessingTimeout
-	}
-
-	return n.waitForState(ctx, d, timeout, "prepared", "ready")
+func (n *Netlify) WaitUntilDeployReady(ctx context.Context, d *models.Deploy) (*models.Deploy, error) {
+	return n.waitForState(ctx, d, "prepared", "ready")
 }
 
 // WaitUntilDeployLive blocks until the deploy is in the or "ready" state. At this point, the deploy is ready to recieve traffic.
-func (n *Netlify) WaitUntilDeployLive(ctx context.Context, d *models.Deploy, timeout time.Duration) (*models.Deploy, error) {
-	if timeout <= 0 {
-		timeout = preProcessingTimeout
-	}
-
-	return n.waitForState(ctx, d, timeout, "ready")
+func (n *Netlify) WaitUntilDeployLive(ctx context.Context, d *models.Deploy) (*models.Deploy, error) {
+	return n.waitForState(ctx, d, "ready")
 }
 
 func (n *Netlify) uploadFiles(ctx context.Context, d *models.Deploy, files *deployFiles, observer DeployObserver, t uploadType, timeout time.Duration) error {

--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -330,11 +330,11 @@ func (n *Netlify) waitForState(ctx context.Context, d *models.Deploy, timeout ti
 		}
 
 		if resp.Payload.State == "error" {
-			return nil, fmt.Errorf("Error: entered errors state while waiting to enter states: %s", strings.Join(states, ","))
+			return nil, fmt.Errorf("Error: entered error state while waiting to enter states: %s", strings.Join(states, ", "))
 		}
 
 		if t.Sub(start) > timeout {
-			return nil, fmt.Errorf("Error: deploy timed out while waiting to enter states: %s", strings.Join(states, ","))
+			return nil, fmt.Errorf("Error: deploy timed out while waiting to enter states: %s", strings.Join(states, ", "))
 		}
 	}
 


### PR DESCRIPTION
Part of https://github.com/netlify/buildbot/issues/1129

Rather than using the build's preprocess timelimit while waiting for a site to go live, we'd like to apply no timelimit other than the overall build timelimit.

Functions that wait for a deploy to enter a certain state take a context, so they don't need to also take a `timelimit` - the time limit can instead be added to the context, and the context's deadline/cancellation can be respected.

The gives users of this package more flexibility, because they can set a time limit on the context, or reuse a context that already has a timeout or cancellation function.

I also pushed setting the default preprocess time limit on `WaitUntilDeployReady` into the caller, `DoDeploy`. I think this is a better fit for the responsibilities of that function and is more symmetrical with `WaitUntilDeployLive`.