### PR TITLE
fix: use module v2 in package example

### DIFF
--- a/go/plumbing/example_test.go
+++ b/go/plumbing/example_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
-	"github.com/netlify/open-api/go/plumbing/operations"
+	"github.com/netlify/open-api/v2/go/plumbing/operations"
 )
 
 func Example() {


### PR DESCRIPTION
This code was in master but not the PR branch, so it didn't get the `v2` update all the other files got.