### PR TITLE
fix: don't wrap sharedErr on failed upload

### DIFF
--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -21,15 +21,14 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	apierrors "github.com/go-openapi/errors"
 	"github.com/pkg/errors"
+	"github.com/rsc/goversion/version"
 	"github.com/sirupsen/logrus"
 
 	"github.com/netlify/open-api/v2/go/models"
 	"github.com/netlify/open-api/v2/go/plumbing/operations"
 	"github.com/netlify/open-api/v2/go/porcelain/context"
-
-	apierrors "github.com/go-openapi/errors"
-	"github.com/rsc/goversion/version"
 )
 
 const (
@@ -439,7 +438,7 @@ func (n *Netlify) uploadFile(ctx context.Context, d *models.Deploy, f *FileBundl
 
 		if sharedErr.err != nil {
 			sharedErr.mutex.Unlock()
-			return errors.Wrapf(sharedErr.err, "aborting upload of file %s due to upload failure", f.Name)
+			return fmt.Errorf("aborting upload of file %s due to failed upload of another file", f.Name)
 		}
 		sharedErr.mutex.Unlock()
 


### PR DESCRIPTION
I thought it would be nice to have the context of the `err` here. However, this `sharedErr` is getting updated by every file attempting to do the upload.

Here's what's happening:
* File 1 fails to upload after some retries with exponential backoff, and sets `sharedErr` saying it failed
* File 2 sees that `sharedErr` isn't nil, so it gives up as well, and wraps the `sharedErr` with its own message
* File 3 sees the *wrapped* `sharedErr` and wraps it again with its own message
* Repeat for files 4 - 100 to create a very ugly error

The causes a deeply nested error and it really doesn't look good. We're logging the original failure like below, so we can see it that way in the logs instead. https://github.com/netlify/open-api/blob/71cc689d4a5e3797563917d9c0e15a9270ecfec0/go/porcelain/deploy.go#L472