### PR TITLE
feat: add functions_dir in repo info

### DIFF
--- a/go/models/repo_info.go
+++ b/go/models/repo_info.go
@@ -30,6 +30,9 @@ type RepoInfo struct {
 	// env
 	Env map[string]string `json:"env,omitempty"`
 
+	// functions dir
+	FunctionsDir string `json:"functions_dir,omitempty"`
+
 	// id
 	ID int64 `json:"id,omitempty"`
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -2140,6 +2140,8 @@ definitions:
         type: string
       dir:
         type: string
+      functions_dir:
+        type: string
       cmd:
         type: string
       allowed_branches:


### PR DESCRIPTION
Allow specifying the functions directory when creating sites.