### PR TITLE
feat: add framework to deploy properties

### DIFF
--- a/go/models/deploy.go
+++ b/go/models/deploy.go
@@ -49,6 +49,9 @@ type Deploy struct {
 	// error message
 	ErrorMessage string `json:"error_message,omitempty"`
 
+	// framework
+	Framework string `json:"framework,omitempty"`
+
 	// id
 	ID string `json:"id,omitempty"`
 

--- a/go/models/deploy_files.go
+++ b/go/models/deploy_files.go
@@ -27,6 +27,9 @@ type DeployFiles struct {
 	// files
 	Files interface{} `json:"files,omitempty"`
 
+	// framework
+	Framework string `json:"framework,omitempty"`
+
 	// functions
 	Functions interface{} `json:"functions,omitempty"`
 }

--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -83,6 +83,7 @@ type DeployOptions struct {
 	Title             string
 	Branch            string
 	CommitRef         string
+	Framework         string
 	UploadTimeout     time.Duration
 	PreProcessTimeout time.Duration
 
@@ -220,9 +221,10 @@ func (n *Netlify) DoDeploy(ctx context.Context, options *DeployOptions, deploy *
 	options.functions = functions
 
 	deployFiles := &models.DeployFiles{
-		Files: options.files.Sums,
-		Draft: options.IsDraft,
-		Async: n.overCommitted(options.files),
+		Files:     options.files.Sums,
+		Draft:     options.IsDraft,
+		Async:     n.overCommitted(options.files),
+		Framework: options.Framework,
 	}
 	if options.functions != nil {
 		deployFiles.Functions = options.functions.Sums

--- a/swagger.yml
+++ b/swagger.yml
@@ -2358,6 +2358,8 @@ definitions:
         properties:
           large_media_enabled:
             type: boolean
+      framework:
+        type: string
   deployFiles:
     type: object
     properties:

--- a/swagger.yml
+++ b/swagger.yml
@@ -2373,6 +2373,8 @@ definitions:
         type: object
       branch:
         type: string
+      framework:
+        type: string
   buildStatus:
     type: object
     properties:


### PR DESCRIPTION
Allows setting the detected framework on a deploy and accessing the value from the API.

Part of https://github.com/netlify/pod-workflow/issues/159