### PR TITLE
fix: Switch site update to a put request

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -111,7 +111,7 @@ paths:
             $ref: '#/definitions/site'
         default:
           $ref: '#/responses/error'
-    patch:
+    put:
       operationId: updateSite
       tags: [site]
       consumes:


### PR DESCRIPTION
Hello! Hope you don't mind a proposed contribution from a lowly open-source developer.

It appears that the request type is incorrect for the updateSite endpoint, although I'm obviously new to this API and can't quite confirm. This is causing problems for me because I'm using the Node API generated by this specification, and the patch request doesn't seem to be having the side-effects that I'm looking for. For example:

Manually updating the custom_domain via the UI makes a PUT request, which works as expected:
<img width="383" alt="Screen Shot 2021-04-18 at 11 15 02 AM" src="https://user-images.githubusercontent.com/2266534/115153361-250c2680-a03b-11eb-9459-d08d88c762fc.png">

Calling the API function with the same parameters against (theoretically) the same endpoint does not, and I think the incorrect request type might be the culprit:
<img width="383" alt="Screen Shot 2021-04-18 at 11 45 23 AM" src="https://user-images.githubusercontent.com/2266534/115153451-91872580-a03b-11eb-8dad-552cf2bba49b.png">
<img width="259" alt="Screen Shot 2021-04-18 at 11 23 00 AM" src="https://user-images.githubusercontent.com/2266534/115153397-4836d600-a03b-11eb-9939-326dd818b78e.png">

I'm hoping this change in tandem with an API regeneration would fix that problem, but feel free to correct me!