### PR TITLE
fix: fix the HTTP method for the site rollback endpoint

### DIFF
--- a/go/plumbing/operations/operations_client.go
+++ b/go/plumbing/operations/operations_client.go
@@ -3148,7 +3148,7 @@ func (a *Client) RollbackSiteDeploy(params *RollbackSiteDeployParams, authInfo r
 
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "rollbackSiteDeploy",
-		Method:             "POST",
+		Method:             "PUT",
 		PathPattern:        "/sites/{site_id}/rollback",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},

--- a/go/plumbing/operations/rollback_site_deploy_responses.go
+++ b/go/plumbing/operations/rollback_site_deploy_responses.go
@@ -54,7 +54,7 @@ type RollbackSiteDeployNoContent struct {
 }
 
 func (o *RollbackSiteDeployNoContent) Error() string {
-	return fmt.Sprintf("[POST /sites/{site_id}/rollback][%d] rollbackSiteDeployNoContent ", 204)
+	return fmt.Sprintf("[PUT /sites/{site_id}/rollback][%d] rollbackSiteDeployNoContent ", 204)
 }
 
 func (o *RollbackSiteDeployNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -85,7 +85,7 @@ func (o *RollbackSiteDeployDefault) Code() int {
 }
 
 func (o *RollbackSiteDeployDefault) Error() string {
-	return fmt.Sprintf("[POST /sites/{site_id}/rollback][%d] rollbackSiteDeploy default  %+v", o._statusCode, o.Payload)
+	return fmt.Sprintf("[PUT /sites/{site_id}/rollback][%d] rollbackSiteDeploy default  %+v", o._statusCode, o.Payload)
 }
 
 func (o *RollbackSiteDeployDefault) GetPayload() *models.Error {

--- a/swagger.yml
+++ b/swagger.yml
@@ -874,7 +874,7 @@ paths:
         type: string
         in: path
         required: true
-    post:
+    put:
       operationId: rollbackSiteDeploy
       tags: [deploy]
       responses:


### PR DESCRIPTION
Thanks to the report in https://answers.netlify.com/t/rollback-api-endpoint-returns-404/39157, we noticed the 🐛 in our swagger file. This endpoint was created as PUT (never was POST), so let's fix it.

reference: bitballoon route file https://github.com/netlify/bitballoon/blob/121b33b52afbb5a2842e5c8c78728d92ca0772bc/config/routes.rb#L238