### PR TITLE
feat: add support for scheduled functions to Go client

### DIFF
--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -240,8 +240,9 @@ func (n *Netlify) DoDeploy(ctx context.Context, options *DeployOptions, deploy *
 
 	l := context.GetLogger(ctx)
 	l.WithFields(logrus.Fields{
-		"site_id":      options.SiteID,
-		"deploy_files": len(options.files.Sums),
+		"site_id":             options.SiteID,
+		"deploy_files":        len(options.files.Sums),
+		"scheduled_functions": len(schedules),
 	}).Debug("Starting to deploy files")
 	authInfo := context.GetAuthInfo(ctx)
 

--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -650,7 +650,8 @@ func bundleFromManifest(ctx context.Context, manifestFile *os.File, observer Dep
 		return nil, nil, err
 	}
 
-	context.GetLogger(ctx).Debug("Found functions manifest file")
+	logger := context.GetLogger(ctx)
+	logger.Debug("Found functions manifest file")
 
 	var manifest functionsManifest
 

--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -650,9 +650,7 @@ func bundleFromManifest(ctx context.Context, manifestFile *os.File, observer Dep
 		return nil, nil, err
 	}
 
-	context.GetLogger(ctx).WithFields(logrus.Fields{
-		"manifest": string(manifestBytes),
-	}).Debug("Found functions manifest file")
+	context.GetLogger(ctx).Debug("Found functions manifest file")
 
 	var manifest functionsManifest
 

--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -240,8 +240,10 @@ func (n *Netlify) DoDeploy(ctx context.Context, options *DeployOptions, deploy *
 
 	l := context.GetLogger(ctx)
 	l.WithFields(logrus.Fields{
-		"site_id":      options.SiteID,
-		"deploy_files": len(options.files.Sums),
+		"site_id":            options.SiteID,
+		"deploy_files":       len(options.files.Sums),
+		"functions":          len(functions.Files),
+		"function_schedules": len(schedules),
 	}).Debug("Starting to deploy files")
 	authInfo := context.GetAuthInfo(ctx)
 

--- a/go/porcelain/deploy_test.go
+++ b/go/porcelain/deploy_test.go
@@ -203,7 +203,7 @@ func TestUploadFiles_Cancelation(t *testing.T) {
 }
 
 func TestBundle(t *testing.T) {
-	functions, schedules, err := bundle("../internal/data", mockObserver{})
+	functions, schedules, err := bundle(gocontext.Background(), "../internal/data", mockObserver{})
 
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(functions.Files))
@@ -247,7 +247,7 @@ func TestBundleWithManifest(t *testing.T) {
 	defer os.Remove(manifestPath)
 	assert.Nil(t, err)
 
-	functions, schedules, err := bundle("../internal/data", mockObserver{})
+	functions, schedules, err := bundle(gocontext.Background(), "../internal/data", mockObserver{})
 
 	assert.Nil(t, err)
 


### PR DESCRIPTION
- Adds a `FunctionSchedules` property to the deploy options when function schedules are detected
- Adds a `scheduled_functions` log field to an existing log message, showing the number of scheduled functions detected for the deploy
- Adds a new log message when a functions manifest file is detected