### PR TITLE
feat: add retry count field

### DIFF
--- a/go/plumbing/operations/upload_deploy_function_parameters.go
+++ b/go/plumbing/operations/upload_deploy_function_parameters.go
@@ -62,6 +62,8 @@ for the upload deploy function operation typically these are written to a http.R
 */
 type UploadDeployFunctionParams struct {
 
+	/*XNfRetryCount*/
+	XNfRetryCount *int64
 	/*DeployID*/
 	DeployID string
 	/*FileBody*/
@@ -109,6 +111,17 @@ func (o *UploadDeployFunctionParams) WithHTTPClient(client *http.Client) *Upload
 // SetHTTPClient adds the HTTPClient to the upload deploy function params
 func (o *UploadDeployFunctionParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
+}
+
+// WithXNfRetryCount adds the xNfRetryCount to the upload deploy function params
+func (o *UploadDeployFunctionParams) WithXNfRetryCount(xNfRetryCount *int64) *UploadDeployFunctionParams {
+	o.SetXNfRetryCount(xNfRetryCount)
+	return o
+}
+
+// SetXNfRetryCount adds the xNfRetryCount to the upload deploy function params
+func (o *UploadDeployFunctionParams) SetXNfRetryCount(xNfRetryCount *int64) {
+	o.XNfRetryCount = xNfRetryCount
 }
 
 // WithDeployID adds the deployID to the upload deploy function params
@@ -173,6 +186,15 @@ func (o *UploadDeployFunctionParams) WriteToRequest(r runtime.ClientRequest, reg
 		return err
 	}
 	var res []error
+
+	if o.XNfRetryCount != nil {
+
+		// header param X-Nf-Retry-Count
+		if err := r.SetHeaderParam("X-Nf-Retry-Count", swag.FormatInt64(*o.XNfRetryCount)); err != nil {
+			return err
+		}
+
+	}
 
 	// path param deploy_id
 	if err := r.SetPathParam("deploy_id", o.DeployID); err != nil {

--- a/swagger.yml
+++ b/swagger.yml
@@ -1248,6 +1248,7 @@ paths:
             type: string
             format: binary
           required: true
+        - $ref: '#/parameters/retryCount'
       responses:
         '200':
           description: OK
@@ -3378,6 +3379,10 @@ parameters:
     name: per_page
     required: false
     in: query
+  retryCount:
+    name: X-Nf-Retry-Count
+    type: integer
+    in: header    
 x-tagGroups:
   - name: OAuth
     tags:


### PR DESCRIPTION
When clients retry an operation, we would like to propagate the retry number to the API, so that it can adjust its behaviour accordingly.

To do this, this PR adds a `X-Nf-Retry-Count` header, which is empty on the first attempt, and contains `1` on the first retry, and so on.

Currently, we're adding the field to the `uploadDeployFunction` only.

Part of https://github.com/netlify/pod-compute/issues/140.