### PR TITLE
fix(createSiteBuild): add clear_cache field

### DIFF
--- a/go/models/build_setup.go
+++ b/go/models/build_setup.go
@@ -15,6 +15,9 @@ import (
 // swagger:model buildSetup
 type BuildSetup struct {
 
+	// clear cache
+	ClearCache bool `json:"clear_cache,omitempty"`
+
 	// image
 	Image string `json:"image,omitempty"`
 }

--- a/swagger.yml
+++ b/swagger.yml
@@ -3322,6 +3322,8 @@ definitions:
     properties:
       image:
         type: string
+      clear_cache:
+        type: boolean
   buildHookSetup:
     type: object
     properties:


### PR DESCRIPTION
Fixes #398 and #396. Adds the missing `clear_cache` field to the `createSiteBuild` method.