### PR TITLE
chore: remove beta tags from CLI and docs

### DIFF
--- a/go/plumbing/operations/operations_client.go
+++ b/go/plumbing/operations/operations_client.go
@@ -533,7 +533,7 @@ func (a *Client) CreateDNSZone(params *CreateDNSZoneParams, authInfo runtime.Cli
 }
 
 /*
-  CreateEnvVars Creates new environment variables. Granular scopes are available on Pro plans and above.  To use this endpoint, opt in to the beta environment variable experience using the Netlify UI.
+  CreateEnvVars Creates new environment variables. Granular scopes are available on Pro plans and above. To use this endpoint, your site must no longer be using the classic environment experience. Migrate now with the Netlify UI.
 */
 func (a *Client) CreateEnvVars(params *CreateEnvVarsParams, authInfo runtime.ClientAuthInfoWriter) (*CreateEnvVarsCreated, error) {
 	// TODO: Validate the params before sending
@@ -1077,7 +1077,7 @@ func (a *Client) DeleteDNSZone(params *DeleteDNSZoneParams, authInfo runtime.Cli
 }
 
 /*
-  DeleteEnvVar Deletes an environment variable. To use this endpoint, opt in to the beta environment variable experience using the Netlify UI.
+  DeleteEnvVar Deletes an environment variable. To use this endpoint, your site must no longer be using the classic environment experience. Migrate now with the Netlify UI
 */
 func (a *Client) DeleteEnvVar(params *DeleteEnvVarParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteEnvVarNoContent, error) {
 	// TODO: Validate the params before sending
@@ -1111,7 +1111,7 @@ func (a *Client) DeleteEnvVar(params *DeleteEnvVarParams, authInfo runtime.Clien
 }
 
 /*
-  DeleteEnvVarValue Deletes a specific environment variable value. To use this endpoint,  opt in to the beta environment variable experience using the Netlify UI.
+  DeleteEnvVarValue Deletes a specific environment variable value. To use this endpoint, your site must no longer be using the classic environment experience. Migrate now with the Netlify UI.
 */
 func (a *Client) DeleteEnvVarValue(params *DeleteEnvVarValueParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteEnvVarValueNoContent, error) {
 	// TODO: Validate the params before sending
@@ -1860,7 +1860,7 @@ func (a *Client) GetDNSZones(params *GetDNSZonesParams, authInfo runtime.ClientA
 }
 
 /*
-  GetEnvVar Returns an individual environment variable. To use this endpoint, opt in to the beta environment variable experience using the Netlify UI.
+  GetEnvVar Returns an individual environment variable. To use this endpoint, your site must no longer be using the classic environment experience. Migrate now with the Netlify UI.
 */
 func (a *Client) GetEnvVar(params *GetEnvVarParams, authInfo runtime.ClientAuthInfoWriter) (*GetEnvVarOK, error) {
 	// TODO: Validate the params before sending
@@ -1894,7 +1894,7 @@ func (a *Client) GetEnvVar(params *GetEnvVarParams, authInfo runtime.ClientAuthI
 }
 
 /*
-  GetEnvVars Returns all environment variables for an account or site. An account corresponds to a team in the Netlify UI. To use this endpoint, opt in to the beta environment variable experience using the Netlify UI.
+  GetEnvVars Returns all environment variables for an account or site. An account corresponds to a team in the Netlify UI. To use this endpoint, your site must no longer be using the classic environment experience. Migrate now with the Netlify UI.
 */
 func (a *Client) GetEnvVars(params *GetEnvVarsParams, authInfo runtime.ClientAuthInfoWriter) (*GetEnvVarsOK, error) {
 	// TODO: Validate the params before sending
@@ -3356,7 +3356,7 @@ func (a *Client) RollbackSiteDeploy(params *RollbackSiteDeployParams, authInfo r
 }
 
 /*
-  SetEnvVarValue Updates or creates a new value for an existing environment variable. To use this endpoint, opt in to the beta environment variable experience using the Netlify UI.
+  SetEnvVarValue Updates or creates a new value for an existing environment variable. To use this endpoint, your site must no longer be using the classic environment experience. Migrate now with the Netlify UI.
 */
 func (a *Client) SetEnvVarValue(params *SetEnvVarValueParams, authInfo runtime.ClientAuthInfoWriter) (*SetEnvVarValueCreated, error) {
 	// TODO: Validate the params before sending
@@ -3702,7 +3702,7 @@ func (a *Client) UpdateAccount(params *UpdateAccountParams, authInfo runtime.Cli
 }
 
 /*
-  UpdateEnvVar Updates an existing environment variable and all of its values. Existing values will be replaced by values provided. To use this endpoint, opt in to the beta environment variable experience using the Netlify UI.
+  UpdateEnvVar Updates an existing environment variable and all of its values. Existing values will be replaced by values provided. To use this endpoint, your site must no longer be using the classic environment experience. Migrate now with the Netlify UI.
 */
 func (a *Client) UpdateEnvVar(params *UpdateEnvVarParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateEnvVarOK, error) {
 	// TODO: Validate the params before sending

--- a/go/plumbing/operations/operations_client.go
+++ b/go/plumbing/operations/operations_client.go
@@ -533,7 +533,7 @@ func (a *Client) CreateDNSZone(params *CreateDNSZoneParams, authInfo runtime.Cli
 }
 
 /*
-  CreateEnvVars Creates new environment variables. Granular scopes are available on Pro plans and above. To use this endpoint, your site must no longer be using the classic environment experience. Migrate now with the Netlify UI.
+  CreateEnvVars Creates new environment variables. Granular scopes are available on Pro plans and above. To use this endpoint, your site must no longer be using the <a href="https://docs.netlify.com/environment-variables/classic-experience/">classic environment variables experience</a>.  Migrate now with the Netlify UI.
 */
 func (a *Client) CreateEnvVars(params *CreateEnvVarsParams, authInfo runtime.ClientAuthInfoWriter) (*CreateEnvVarsCreated, error) {
 	// TODO: Validate the params before sending
@@ -1077,7 +1077,7 @@ func (a *Client) DeleteDNSZone(params *DeleteDNSZoneParams, authInfo runtime.Cli
 }
 
 /*
-  DeleteEnvVar Deletes an environment variable. To use this endpoint, your site must no longer be using the classic environment experience. Migrate now with the Netlify UI
+  DeleteEnvVar Deletes an environment variable. To use this endpoint, your site must no longer be using the <a href="https://docs.netlify.com/environment-variables/classic-experience/">classic environment variables experience</a>.  Migrate now with the Netlify UI
 */
 func (a *Client) DeleteEnvVar(params *DeleteEnvVarParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteEnvVarNoContent, error) {
 	// TODO: Validate the params before sending
@@ -1111,7 +1111,7 @@ func (a *Client) DeleteEnvVar(params *DeleteEnvVarParams, authInfo runtime.Clien
 }
 
 /*
-  DeleteEnvVarValue Deletes a specific environment variable value. To use this endpoint, your site must no longer be using the classic environment experience. Migrate now with the Netlify UI.
+  DeleteEnvVarValue Deletes a specific environment variable value. To use this endpoint, your site must no longer be using the <a href="https://docs.netlify.com/environment-variables/classic-experience/">classic environment variables experience</a>.  Migrate now with the Netlify UI.
 */
 func (a *Client) DeleteEnvVarValue(params *DeleteEnvVarValueParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteEnvVarValueNoContent, error) {
 	// TODO: Validate the params before sending
@@ -1860,7 +1860,7 @@ func (a *Client) GetDNSZones(params *GetDNSZonesParams, authInfo runtime.ClientA
 }
 
 /*
-  GetEnvVar Returns an individual environment variable. To use this endpoint, your site must no longer be using the classic environment experience. Migrate now with the Netlify UI.
+  GetEnvVar Returns an individual environment variable. To use this endpoint, your site must no longer be using the <a href="https://docs.netlify.com/environment-variables/classic-experience/">classic environment variables experience</a>.  Migrate now with the Netlify UI.
 */
 func (a *Client) GetEnvVar(params *GetEnvVarParams, authInfo runtime.ClientAuthInfoWriter) (*GetEnvVarOK, error) {
 	// TODO: Validate the params before sending
@@ -1894,7 +1894,7 @@ func (a *Client) GetEnvVar(params *GetEnvVarParams, authInfo runtime.ClientAuthI
 }
 
 /*
-  GetEnvVars Returns all environment variables for an account or site. An account corresponds to a team in the Netlify UI. To use this endpoint, your site must no longer be using the classic environment experience. Migrate now with the Netlify UI.
+  GetEnvVars Returns all environment variables for an account or site. An account corresponds to a team in the Netlify UI. To use this endpoint, your site must no longer be using the <a href="https://docs.netlify.com/environment-variables/classic-experience/">classic environment variables experience</a>.  Migrate now with the Netlify UI.
 */
 func (a *Client) GetEnvVars(params *GetEnvVarsParams, authInfo runtime.ClientAuthInfoWriter) (*GetEnvVarsOK, error) {
 	// TODO: Validate the params before sending
@@ -3356,7 +3356,7 @@ func (a *Client) RollbackSiteDeploy(params *RollbackSiteDeployParams, authInfo r
 }
 
 /*
-  SetEnvVarValue Updates or creates a new value for an existing environment variable. To use this endpoint, your site must no longer be using the classic environment experience. Migrate now with the Netlify UI.
+  SetEnvVarValue Updates or creates a new value for an existing environment variable. To use this endpoint, your site must no longer be using the <a href="https://docs.netlify.com/environment-variables/classic-experience/">classic environment variables experience</a>.  Migrate now with the Netlify UI.
 */
 func (a *Client) SetEnvVarValue(params *SetEnvVarValueParams, authInfo runtime.ClientAuthInfoWriter) (*SetEnvVarValueCreated, error) {
 	// TODO: Validate the params before sending
@@ -3702,7 +3702,7 @@ func (a *Client) UpdateAccount(params *UpdateAccountParams, authInfo runtime.Cli
 }
 
 /*
-  UpdateEnvVar Updates an existing environment variable and all of its values. Existing values will be replaced by values provided. To use this endpoint, your site must no longer be using the classic environment experience. Migrate now with the Netlify UI.
+  UpdateEnvVar Updates an existing environment variable and all of its values. Existing values will be replaced by values provided. To use this endpoint, your site must no longer be using the <a href="https://docs.netlify.com/environment-variables/classic-experience/">classic environment variables experience</a>.  Migrate now with the Netlify UI.
 */
 func (a *Client) UpdateEnvVar(params *UpdateEnvVarParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateEnvVarOK, error) {
 	// TODO: Validate the params before sending

--- a/go/plumbing/operations/operations_client.go
+++ b/go/plumbing/operations/operations_client.go
@@ -533,7 +533,7 @@ func (a *Client) CreateDNSZone(params *CreateDNSZoneParams, authInfo runtime.Cli
 }
 
 /*
-  CreateEnvVars [Beta] Creates new environment variables. Granular scopes are available on Pro plans and above.  To use this endpoint, opt in to the beta environment variable experience using the Netlify UI.
+  CreateEnvVars Creates new environment variables. Granular scopes are available on Pro plans and above.  To use this endpoint, opt in to the beta environment variable experience using the Netlify UI.
 */
 func (a *Client) CreateEnvVars(params *CreateEnvVarsParams, authInfo runtime.ClientAuthInfoWriter) (*CreateEnvVarsCreated, error) {
 	// TODO: Validate the params before sending
@@ -1077,7 +1077,7 @@ func (a *Client) DeleteDNSZone(params *DeleteDNSZoneParams, authInfo runtime.Cli
 }
 
 /*
-  DeleteEnvVar [Beta] Deletes an environment variable. To use this endpoint, opt in to the beta environment variable experience using the Netlify UI.
+  DeleteEnvVar Deletes an environment variable. To use this endpoint, opt in to the beta environment variable experience using the Netlify UI.
 */
 func (a *Client) DeleteEnvVar(params *DeleteEnvVarParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteEnvVarNoContent, error) {
 	// TODO: Validate the params before sending
@@ -1111,7 +1111,7 @@ func (a *Client) DeleteEnvVar(params *DeleteEnvVarParams, authInfo runtime.Clien
 }
 
 /*
-  DeleteEnvVarValue [Beta] Deletes a specific environment variable value. To use this endpoint,  opt in to the beta environment variable experience using the Netlify UI.
+  DeleteEnvVarValue Deletes a specific environment variable value. To use this endpoint,  opt in to the beta environment variable experience using the Netlify UI.
 */
 func (a *Client) DeleteEnvVarValue(params *DeleteEnvVarValueParams, authInfo runtime.ClientAuthInfoWriter) (*DeleteEnvVarValueNoContent, error) {
 	// TODO: Validate the params before sending
@@ -1860,7 +1860,7 @@ func (a *Client) GetDNSZones(params *GetDNSZonesParams, authInfo runtime.ClientA
 }
 
 /*
-  GetEnvVar [Beta] Returns an individual environment variable. To use this endpoint, opt in to the beta environment variable experience using the Netlify UI.
+  GetEnvVar Returns an individual environment variable. To use this endpoint, opt in to the beta environment variable experience using the Netlify UI.
 */
 func (a *Client) GetEnvVar(params *GetEnvVarParams, authInfo runtime.ClientAuthInfoWriter) (*GetEnvVarOK, error) {
 	// TODO: Validate the params before sending
@@ -1894,7 +1894,7 @@ func (a *Client) GetEnvVar(params *GetEnvVarParams, authInfo runtime.ClientAuthI
 }
 
 /*
-  GetEnvVars [Beta] Returns all environment variables for an account or site. An account corresponds to a team in the Netlify UI. To use this endpoint, opt in to the beta environment variable experience using the Netlify UI.
+  GetEnvVars Returns all environment variables for an account or site. An account corresponds to a team in the Netlify UI. To use this endpoint, opt in to the beta environment variable experience using the Netlify UI.
 */
 func (a *Client) GetEnvVars(params *GetEnvVarsParams, authInfo runtime.ClientAuthInfoWriter) (*GetEnvVarsOK, error) {
 	// TODO: Validate the params before sending
@@ -3356,7 +3356,7 @@ func (a *Client) RollbackSiteDeploy(params *RollbackSiteDeployParams, authInfo r
 }
 
 /*
-  SetEnvVarValue [Beta] Updates or creates a new value for an existing environment variable. To use this endpoint, opt in to the beta environment variable experience using the Netlify UI.
+  SetEnvVarValue Updates or creates a new value for an existing environment variable. To use this endpoint, opt in to the beta environment variable experience using the Netlify UI.
 */
 func (a *Client) SetEnvVarValue(params *SetEnvVarValueParams, authInfo runtime.ClientAuthInfoWriter) (*SetEnvVarValueCreated, error) {
 	// TODO: Validate the params before sending
@@ -3702,7 +3702,7 @@ func (a *Client) UpdateAccount(params *UpdateAccountParams, authInfo runtime.Cli
 }
 
 /*
-  UpdateEnvVar [Beta] Updates an existing environment variable and all of its values. Existing values will be replaced by values provided. To use this endpoint, opt in to the beta environment variable experience using the Netlify UI.
+  UpdateEnvVar Updates an existing environment variable and all of its values. Existing values will be replaced by values provided. To use this endpoint, opt in to the beta environment variable experience using the Netlify UI.
 */
 func (a *Client) UpdateEnvVar(params *UpdateEnvVarParams, authInfo runtime.ClientAuthInfoWriter) (*UpdateEnvVarOK, error) {
 	// TODO: Validate the params before sending

--- a/swagger.yml
+++ b/swagger.yml
@@ -315,7 +315,7 @@ paths:
         default:
           $ref: '#/responses/error'
       description: >-
-        Returns an individual environment variable. To use this endpoint, your site
+        Returns an individual environment variable. To use this endpoint, your site 
         must no longer be using the classic environment experience. Migrate now with the Netlify UI.
     put:
       tags:
@@ -323,7 +323,7 @@ paths:
       operationId: updateEnvVar
       description: >-
         Updates an existing environment variable and all of its values.
-        Existing values will be replaced by values provided. To use this endpoint, your site must
+        Existing values will be replaced by values provided. To use this endpoint, your site must 
         no longer be using the classic environment experience. Migrate now with the Netlify UI.
       parameters:
         - name: account_id
@@ -378,7 +378,7 @@ paths:
         - environmentVariables
       operationId: setEnvVarValue
       description: >-
-        Updates or creates a new value for an existing environment variable. To use this endpoint, your site
+        Updates or creates a new value for an existing environment variable. To use this endpoint, your site 
         must no longer be using the classic environment experience. Migrate now with the Netlify UI.
       parameters:
         - name: account_id
@@ -445,7 +445,7 @@ paths:
         default:
           $ref: '#/responses/error'
       description: >-
-        Deletes an environment variable. To use this endpoint, your site must no
+        Deletes an environment variable. To use this endpoint, your site must no 
         longer be using the classic environment experience. Migrate now with the Netlify UI.
   /accounts/{account_id}/env/{key}/value/{id}:
     delete:
@@ -481,7 +481,7 @@ paths:
         default:
           $ref: '#/responses/error'
       description: >-
-        Deletes a specific environment variable value. To use this endpoint, your site
+        Deletes a specific environment variable value. To use this endpoint, your site 
         must no longer be using the classic environment experience. Migrate now with the Netlify UI.
   /sites/{site_id}/forms:
     get:

--- a/swagger.yml
+++ b/swagger.yml
@@ -226,7 +226,7 @@ paths:
       description: >-
         Returns all environment variables for an account or site. An
         account corresponds to a team in the Netlify UI. To use this endpoint, your 
-        site must no longer be using the classic environment experience. Migrate now with the Netlify UI.
+        site must no longer be using the <a href="https://docs.netlify.com/environment-variables/classic-experience/">classic environment variables experience</a>.  Migrate now with the Netlify UI.
     post:
       tags:
         - environmentVariables
@@ -234,7 +234,7 @@ paths:
       description: >-
         Creates new environment variables. Granular scopes are available
         on Pro plans and above.  To use this endpoint, your site must no longer be 
-        using the classic environment experience. Migrate now with the Netlify UI.
+        using the <a href="https://docs.netlify.com/environment-variables/classic-experience/">classic environment variables experience</a>.  Migrate now with the Netlify UI.
       parameters:
         - in: body
           name: env_vars
@@ -316,7 +316,7 @@ paths:
           $ref: '#/responses/error'
       description: >-
         Returns an individual environment variable. To use this endpoint, your site 
-        must no longer be using the classic environment experience. Migrate now with the Netlify UI.
+        must no longer be using the <a href="https://docs.netlify.com/environment-variables/classic-experience/">classic environment variables experience</a>.  Migrate now with the Netlify UI.
     put:
       tags:
         - environmentVariables
@@ -324,7 +324,7 @@ paths:
       description: >-
         Updates an existing environment variable and all of its values.
         Existing values will be replaced by values provided. To use this endpoint, your site must 
-        no longer be using the classic environment experience. Migrate now with the Netlify UI.
+        no longer be using the <a href="https://docs.netlify.com/environment-variables/classic-experience/">classic environment variables experience</a>.  Migrate now with the Netlify UI.
       parameters:
         - name: account_id
           description: Scope response to account_id
@@ -379,7 +379,7 @@ paths:
       operationId: setEnvVarValue
       description: >-
         Updates or creates a new value for an existing environment variable. To use this endpoint, your site 
-        must no longer be using the classic environment experience. Migrate now with the Netlify UI.
+        must no longer be using the <a href="https://docs.netlify.com/environment-variables/classic-experience/">classic environment variables experience</a>.  Migrate now with the Netlify UI.
       parameters:
         - name: account_id
           description: Scope response to account_id
@@ -446,7 +446,7 @@ paths:
           $ref: '#/responses/error'
       description: >-
         Deletes an environment variable. To use this endpoint, your site must no 
-        longer be using the classic environment experience. Migrate now with the Netlify UI.
+        longer be using the <a href="https://docs.netlify.com/environment-variables/classic-experience/">classic environment variables experience</a>.  Migrate now with the Netlify UI.
   /accounts/{account_id}/env/{key}/value/{id}:
     delete:
       tags:
@@ -482,7 +482,7 @@ paths:
           $ref: '#/responses/error'
       description: >-
         Deletes a specific environment variable value. To use this endpoint, your site 
-        must no longer be using the classic environment experience. Migrate now with the Netlify UI.
+        must no longer be using the <a href="https://docs.netlify.com/environment-variables/classic-experience/">classic environment variables experience</a>.  Migrate now with the Netlify UI.
   /sites/{site_id}/forms:
     get:
       operationId: listSiteForms

--- a/swagger.yml
+++ b/swagger.yml
@@ -225,16 +225,16 @@ paths:
           $ref: '#/responses/error'
       description: >-
         Returns all environment variables for an account or site. An
-        account corresponds to a team in the Netlify UI. To use this endpoint,
-        opt in to the beta environment variable experience using the Netlify UI.
+        account corresponds to a team in the Netlify UI. To use this endpoint, your 
+        site must no longer be using the classic environment experience. Migrate now with the Netlify UI.
     post:
       tags:
         - environmentVariables
       operationId: createEnvVars
       description: >-
         Creates new environment variables. Granular scopes are available
-        on Pro plans and above.  To use this endpoint, opt in to the beta environment
-        variable experience using the Netlify UI.
+        on Pro plans and above.  To use this endpoint, your site must no longer be 
+        using the classic environment experience. Migrate now with the Netlify UI.
       parameters:
         - in: body
           name: env_vars
@@ -315,16 +315,16 @@ paths:
         default:
           $ref: '#/responses/error'
       description: >-
-        Returns an individual environment variable. To use this endpoint,
-        opt in to the beta environment variable experience using the Netlify UI.
+        Returns an individual environment variable. To use this endpoint, your site
+        must no longer be using the classic environment experience. Migrate now with the Netlify UI.
     put:
       tags:
         - environmentVariables
       operationId: updateEnvVar
       description: >-
         Updates an existing environment variable and all of its values.
-        Existing values will be replaced by values provided. To use this endpoint,
-        opt in to the beta environment variable experience using the Netlify UI.
+        Existing values will be replaced by values provided. To use this endpoint, your site must
+        no longer be using the classic environment experience. Migrate now with the Netlify UI.
       parameters:
         - name: account_id
           description: Scope response to account_id
@@ -378,7 +378,8 @@ paths:
         - environmentVariables
       operationId: setEnvVarValue
       description: >-
-        Updates or creates a new value for an existing environment variable. To use this endpoint, opt in to the beta environment variable experience using the Netlify UI.
+        Updates or creates a new value for an existing environment variable. To use this endpoint, your site
+        must no longer be using the classic environment experience. Migrate now with the Netlify UI.
       parameters:
         - name: account_id
           description: Scope response to account_id
@@ -444,8 +445,8 @@ paths:
         default:
           $ref: '#/responses/error'
       description: >-
-        Deletes an environment variable. To use this endpoint,
-        opt in to the beta environment variable experience using the Netlify UI.
+        Deletes an environment variable. To use this endpoint, your site must no
+        longer be using the classic environment experience. Migrate now with the Netlify UI.
   /accounts/{account_id}/env/{key}/value/{id}:
     delete:
       tags:
@@ -480,8 +481,8 @@ paths:
         default:
           $ref: '#/responses/error'
       description: >-
-        Deletes a specific environment variable value. To use this endpoint, 
-        opt in to the beta environment variable experience using the Netlify UI.
+        Deletes a specific environment variable value. To use this endpoint, your site
+        must no longer be using the classic environment experience. Migrate now with the Netlify UI.
   /sites/{site_id}/forms:
     get:
       operationId: listSiteForms

--- a/swagger.yml
+++ b/swagger.yml
@@ -224,7 +224,7 @@ paths:
         default:
           $ref: '#/responses/error'
       description: >-
-        [Beta] Returns all environment variables for an account or site. An
+        Returns all environment variables for an account or site. An
         account corresponds to a team in the Netlify UI. To use this endpoint,
         opt in to the beta environment variable experience using the Netlify UI.
     post:
@@ -232,7 +232,7 @@ paths:
         - environmentVariables
       operationId: createEnvVars
       description: >-
-        [Beta] Creates new environment variables. Granular scopes are available
+        Creates new environment variables. Granular scopes are available
         on Pro plans and above.  To use this endpoint, opt in to the beta environment
         variable experience using the Netlify UI.
       parameters:
@@ -315,14 +315,14 @@ paths:
         default:
           $ref: '#/responses/error'
       description: >-
-        [Beta] Returns an individual environment variable. To use this endpoint,
+        Returns an individual environment variable. To use this endpoint,
         opt in to the beta environment variable experience using the Netlify UI.
     put:
       tags:
         - environmentVariables
       operationId: updateEnvVar
       description: >-
-        [Beta] Updates an existing environment variable and all of its values.
+        Updates an existing environment variable and all of its values.
         Existing values will be replaced by values provided. To use this endpoint,
         opt in to the beta environment variable experience using the Netlify UI.
       parameters:
@@ -378,7 +378,7 @@ paths:
         - environmentVariables
       operationId: setEnvVarValue
       description: >-
-        [Beta] Updates or creates a new value for an existing environment variable. To use this endpoint, opt in to the beta environment variable experience using the Netlify UI.
+        Updates or creates a new value for an existing environment variable. To use this endpoint, opt in to the beta environment variable experience using the Netlify UI.
       parameters:
         - name: account_id
           description: Scope response to account_id
@@ -444,7 +444,7 @@ paths:
         default:
           $ref: '#/responses/error'
       description: >-
-        [Beta] Deletes an environment variable. To use this endpoint,
+        Deletes an environment variable. To use this endpoint,
         opt in to the beta environment variable experience using the Netlify UI.
   /accounts/{account_id}/env/{key}/value/{id}:
     delete:
@@ -480,7 +480,7 @@ paths:
         default:
           $ref: '#/responses/error'
       description: >-
-        [Beta] Deletes a specific environment variable value. To use this endpoint, 
+        Deletes a specific environment variable value. To use this endpoint, 
         opt in to the beta environment variable experience using the Netlify UI.
   /sites/{site_id}/forms:
     get:


### PR DESCRIPTION
In the CLI and API docs, remove instances of `[Beta]` from netlify env commands and API reference.

Fixes https://github.com/netlify/pillar-workflow/issues/919 (1/2)