### PR TITLE
Allow triggering Test & Validate Go Client workflows manually

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,6 @@
 name: Test
 on:
+  workflow_dispatch:
   # Ensure GitHub actions are not run twice for same commits
   push:
     branches: [master]

--- a/.github/workflows/verify-go-src.yml
+++ b/.github/workflows/verify-go-src.yml
@@ -1,6 +1,7 @@
 name: Verify Go client
 
 on:
+  workflow_dispatch:
   push:
     branches: [master]
   pull_request:


### PR DESCRIPTION
It will be easier debugging issues on checks failing on PRs by running
triggering them on the default branch, to rule out if the problem is
only in the PR or also on the default branch.

With this change, we should on the Actions tab above get a button to trigger manually like this:

![Screen Shot 2022-12-07 at 13 29 39](https://user-images.githubusercontent.com/175286/206179767-69e7eb0c-472b-46d1-b2f6-e6988efe4a06.png)


Documentation:
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch

Part of #395
