### PR TITLE
feat: pass along generator to functionconfig

### DIFF
--- a/go/models/function_config.go
+++ b/go/models/function_config.go
@@ -17,6 +17,9 @@ type FunctionConfig struct {
 
 	// display name
 	DisplayName string `json:"display_name,omitempty"`
+
+	// generator
+	Generator string `json:"generator,omitempty"`
 }
 
 // Validate validates this function config

--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -755,9 +755,10 @@ func bundleFromManifest(ctx context.Context, manifestFile *os.File, observer Dep
 			})
 		}
 
-		if function.DisplayName != "" {
+		if function.DisplayName != "" || function.Generator != "" {
 			functionsConfig[file.Name] = models.FunctionConfig{
 				DisplayName: function.DisplayName,
+				Generator:   function.Generator,
 			}
 		}
 

--- a/go/porcelain/deploy_test.go
+++ b/go/porcelain/deploy_test.go
@@ -346,6 +346,7 @@ func TestBundleWithManifest(t *testing.T) {
 				"runtime": "a-runtime",
 				"mainFile": "/some/path/hello-js-function-test.js",
 				"displayName": "Hello Javascript Function",
+				"generator": "@netlify/fake-plugin@1.0.0",
 				"name": "hello-js-function-test",
 				"schedule": "* * * * *"
 			},
@@ -376,6 +377,7 @@ func TestBundleWithManifest(t *testing.T) {
 
 	assert.Equal(t, 1, len(functionsConfig))
 	assert.Equal(t, "Hello Javascript Function", functionsConfig["hello-js-function-test"].DisplayName)
+	assert.Equal(t, "@netlify/fake-plugin@1.0.0", functionsConfig["hello-js-function-test"].Generator)
 }
 
 func TestReadZipRuntime(t *testing.T) {

--- a/go/porcelain/functions_manifest.go
+++ b/go/porcelain/functions_manifest.go
@@ -7,10 +7,11 @@ type functionsManifest struct {
 }
 
 type functionsManifestEntry struct {
-	MainFile string `json:"mainFile"`
-	Name     string `json:"name"`
-	Path     string `json:"path"`
-	Runtime  string `json:"runtime"`
-	Schedule string `json:"schedule"`
+	MainFile    string `json:"mainFile"`
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	Runtime     string `json:"runtime"`
+	Schedule    string `json:"schedule"`
 	DisplayName string `json:"displayName"`
+	Generator   string `json:"generator"`
 }

--- a/swagger.yml
+++ b/swagger.yml
@@ -3576,6 +3576,8 @@ definitions:
     properties:
       display_name:
         type: string
+      generator:
+        type: string
 parameters:
   page:
     type: integer


### PR DESCRIPTION
Connected to: https://github.com/netlify/pod-compute/issues/350

Ensures we pass the generator field along with the functionsconfig when deploying serverless functions