### PR TITLE
chore(file-upload): log file size when uploading a file

### DIFF
--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -447,6 +447,7 @@ func (n *Netlify) uploadFile(ctx context.Context, d *models.Deploy, f *FileBundl
 		"deploy_id": d.ID,
 		"file_path": f.Name,
 		"file_sum":  f.Sum,
+		"file_size": f.Size,
 	}).Debug("Uploading file")
 
 	b := backoff.NewExponentialBackOff()


### PR DESCRIPTION
Related with - https://github.com/netlify/pillar-workflow/issues/1126 - adding a field to our debug log line with the size of the file we're uploading.