### PR TITLE
Update JS Client link in swagger.yml

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -21,7 +21,7 @@ info:
 
     - [Go Client](https://github.com/netlify/open-api#go-client)
 
-    - [JS Client](https://github.com/netlify/js-client)
+    - [JS Client](https://github.com/netlify/build/tree/main/packages/js-client)
   termsOfService: https://www.netlify.com/legal/terms-of-use/
   x-logo:
     url: netlify-logo.png


### PR DESCRIPTION
Update JS client link location as former repo location was archived and moved to the build repo.

Related to https://github.com/netlify/open-api/pull/438