### PR TITLE
feat: add runtimeName support to deploy

### DIFF
--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -749,7 +749,14 @@ func bundleFromManifest(ctx context.Context, manifestFile *os.File, observer Dep
 			return nil, nil, nil, fmt.Errorf("manifest file specifies a function path that cannot be found: %s", function.Path)
 		}
 
-		file, err := newFunctionFile(function.Path, fileInfo, function.Runtime, observer)
+		var runtime string
+		if function.RuntimeVersion != "" {
+			runtime = function.RuntimeVersion
+		} else {
+			runtime = function.Runtime
+		}
+
+		file, err := newFunctionFile(function.Path, fileInfo, runtime, observer)
 
 		if err != nil {
 			return nil, nil, nil, err

--- a/go/porcelain/functions_manifest.go
+++ b/go/porcelain/functions_manifest.go
@@ -7,11 +7,12 @@ type functionsManifest struct {
 }
 
 type functionsManifestEntry struct {
-	MainFile    string `json:"mainFile"`
-	Name        string `json:"name"`
-	Path        string `json:"path"`
-	Runtime     string `json:"runtime"`
-	Schedule    string `json:"schedule"`
-	DisplayName string `json:"displayName"`
-	Generator   string `json:"generator"`
+	MainFile       string `json:"mainFile"`
+	Name           string `json:"name"`
+	Path           string `json:"path"`
+	Runtime        string `json:"runtime"`
+	RuntimeVersion string `json:"runtimeVersion"`
+	Schedule       string `json:"schedule"`
+	DisplayName    string `json:"displayName"`
+	Generator      string `json:"generator"`
 }


### PR DESCRIPTION
Reads the runtimeVersion field from the function manifest and forwards it to the API endpoint

This is based on this PR were the new field was added:  https://github.com/netlify/zip-it-and-ship-it/pull/1367

https://github.com/netlify/pod-compute/issues/64