### PR TITLE
fix: Update documentation for Automatic deploy subdomains

### DIFF
--- a/go/models/site.go
+++ b/go/models/site.go
@@ -25,6 +25,9 @@ type Site struct {
 	// admin url
 	AdminURL string `json:"admin_url,omitempty"`
 
+	// branch deploy custom domain
+	BranchDeployCustomDomain string `json:"branch_deploy_custom_domain,omitempty"`
+
 	// build image
 	BuildImage string `json:"build_image,omitempty"`
 
@@ -45,6 +48,9 @@ type Site struct {
 
 	// deploy hook
 	DeployHook string `json:"deploy_hook,omitempty"`
+
+	// deploy preview custom domain
+	DeployPreviewCustomDomain string `json:"deploy_preview_custom_domain,omitempty"`
 
 	// deploy url
 	DeployURL string `json:"deploy_url,omitempty"`

--- a/swagger.yml
+++ b/swagger.yml
@@ -2531,6 +2531,10 @@ definitions:
         type: array
         items:
           type: string
+      branch_deploy_custom_domain:
+        type: string
+      deploy_preview_custom_domain:
+        type: string
       password:
         type: string
       notification_email:


### PR DESCRIPTION
Update documentation for the new Site fields `branch_deploy_custom_domain` and 
`deploy_preview_custom_domain` supporting the Automatic deploy subdomains 
(https://answers.netlify.com/t/new-automatic-deploy-subdomains/87711/6)


Deploy preview:
https://deploy-preview-453--open-api.netlify.app/#tag/site/operation/createSite
(use the browser search for `branch_deploy_custom_domain` or 
`deploy_preview_custom_domain`)