### PR TITLE
fix: load `invocationMode` from manifest

### DIFF
--- a/go/porcelain/deploy_test.go
+++ b/go/porcelain/deploy_test.go
@@ -449,7 +449,7 @@ func TestBundleWithManifest(t *testing.T) {
 				"runtime": "some-other-runtime",
 				"mainFile": "/some/path/hello-py-function-test",
 				"name": "hello-py-function-test",
-				"invocation_mode": "stream"
+				"invocationMode": "stream"
 			}
 		],
 		"version": 1

--- a/go/porcelain/functions_manifest.go
+++ b/go/porcelain/functions_manifest.go
@@ -15,5 +15,5 @@ type functionsManifestEntry struct {
 	Schedule       string `json:"schedule"`
 	DisplayName    string `json:"displayName"`
 	Generator      string `json:"generator"`
-	InvocationMode string `json:"invocation_mode"`
+	InvocationMode string `json:"invocationMode"`
 }


### PR DESCRIPTION
Follow-up to https://github.com/netlify/open-api/pull/454: the right property name from the functions manifest is `invocationMode` 🐫 , not `invocation_mode` 🐍.