### PR TITLE
fix: Add missing env var property - `context_parameter`

### DIFF
--- a/go/models/env_var_value.go
+++ b/go/models/env_var_value.go
@@ -20,8 +20,11 @@ import (
 type EnvVarValue struct {
 
 	// The deploy context in which this value will be used. `dev` refers to local development when running `netlify dev`.
-	// Enum: [all dev branch-deploy deploy-preview production]
+	// Enum: [all dev branch-deploy deploy-preview production branch]
 	Context string `json:"context,omitempty"`
+
+	// An additional parameter for custom branches. Currently, this is used for specifying a branch name when `context=branch`.
+	ContextParameter string `json:"context_parameter,omitempty"`
 
 	// The environment variable value's universally unique ID
 	ID string `json:"id,omitempty"`
@@ -48,7 +51,7 @@ var envVarValueTypeContextPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["all","dev","branch-deploy","deploy-preview","production"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["all","dev","branch-deploy","deploy-preview","production","branch"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -72,6 +75,9 @@ const (
 
 	// EnvVarValueContextProduction captures enum value "production"
 	EnvVarValueContextProduction string = "production"
+
+	// EnvVarValueContextBranch captures enum value "branch"
+	EnvVarValueContextBranch string = "branch"
 )
 
 // prop value enum

--- a/go/models/set_env_var_value_params_body.go
+++ b/go/models/set_env_var_value_params_body.go
@@ -19,9 +19,12 @@ import (
 // swagger:model setEnvVarValueParamsBody
 type SetEnvVarValueParamsBody struct {
 
-	// The deploy context in which this value will be used. `dev` refers to local development when running `netlify dev`.
-	// Enum: [dev branch-deploy deploy-preview production]
+	// The deploy context in which this value will be used. `dev` refers to local development when running `netlify dev`. `branch` must be provided with a value in `context_parameter`.
+	// Enum: [all dev branch-deploy deploy-preview production branch]
 	Context string `json:"context,omitempty"`
+
+	// An additional parameter for custom branches. Currently, this is used for providing a branch name when `context=branch`.
+	ContextParameter string `json:"context_parameter,omitempty"`
 
 	// The environment variable's unencrypted value
 	Value string `json:"value,omitempty"`
@@ -45,7 +48,7 @@ var setEnvVarValueParamsBodyTypeContextPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["dev","branch-deploy","deploy-preview","production"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["all","dev","branch-deploy","deploy-preview","production","branch"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -54,6 +57,9 @@ func init() {
 }
 
 const (
+
+	// SetEnvVarValueParamsBodyContextAll captures enum value "all"
+	SetEnvVarValueParamsBodyContextAll string = "all"
 
 	// SetEnvVarValueParamsBodyContextDev captures enum value "dev"
 	SetEnvVarValueParamsBodyContextDev string = "dev"
@@ -66,6 +72,9 @@ const (
 
 	// SetEnvVarValueParamsBodyContextProduction captures enum value "production"
 	SetEnvVarValueParamsBodyContextProduction string = "production"
+
+	// SetEnvVarValueParamsBodyContextBranch captures enum value "branch"
+	SetEnvVarValueParamsBodyContextBranch string = "branch"
 )
 
 // prop value enum

--- a/swagger.yml
+++ b/swagger.yml
@@ -414,13 +414,18 @@ paths:
             properties:
               context:
                 description: >-
-                  The deploy context in which this value will be used. `dev` refers to local development when running `netlify dev`.
+                  The deploy context in which this value will be used. `dev` refers to local development when running `netlify dev`. `branch` must be provided with a value in `context_parameter`.
                 type: string
                 enum:
+                  - all
                   - dev
                   - branch-deploy
                   - deploy-preview
                   - production
+                  - branch
+              context_parameter:
+                description: An additional parameter for custom branches. Currently, this is used for providing a branch name when `context=branch`.
+                type: string
               value:
                 description: The environment variable's unencrypted value
                 type: string
@@ -2736,9 +2741,13 @@ definitions:
           - branch-deploy
           - deploy-preview
           - production
+          - branch
         description: >-
           The deploy context in which this value will be used. `dev` refers to
           local development when running `netlify dev`.
+      context_parameter:
+        type: string
+        description: An additional parameter for custom branches. Currently, this is used for specifying a branch name when `context=branch`.
     description: Environment variable value model definition
   envVarUser:
     type: object


### PR DESCRIPTION
This issueless PR aims to address some feedback raised to the docs team by the support team.

The API docs are missing information on the env var property `context_parameter` which is used to specify a specific branch name for setting values per deploy context