### PR TITLE
chore: update CODEOWNERS (bulk-codeowners)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @netlify/backend @netlify/backend
-docs/ @netlify/backend @netlify/backend  @netlify/department-docs
-swagger.yml @netlify/backend @netlify/backend  @netlify/department-docs
+* @netlify/backend
+docs/ @netlify/backend @netlify/department-docs 
+swagger.yml @netlify/backend @netlify/department-docs 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-*             @netlify/backend
-docs/         @netlify/backend @netlify/docs
-swagger.yml   @netlify/backend @netlify/docs
+* @netlify/backend @netlify/backend
+docs/ @netlify/backend @netlify/backend  @netlify/department-docs
+swagger.yml @netlify/backend @netlify/backend  @netlify/department-docs


### PR DESCRIPTION

Updating the CODOWNERS file to accomodate the reorg.

## How this change was made
Changes are being made to replace no-longer-valid team names with the names of teams
that are replacing them, and adding what will be the new names for teams that should
exist post-reorg.

The code making these changes is in https://github.com/netlify/codeowners-scanner/

The announcement about this is in [#crew-engineering](https://netlify.slack.com/archives/CPJQSPQE4/p1683313309631019)


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>