### PR TITLE
chore: remove extra unnecessary iteration over deploy files

### DIFF
--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -418,7 +418,7 @@ func (n *Netlify) uploadFiles(ctx context.Context, d *models.Deploy, files *depl
 	count := 0
 	for _, sha := range required {
 		if files, exist := files.Hashed[sha]; exist {
-			count = count + len(files)
+			count += len(files)
 		}
 	}
 

--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -418,9 +418,7 @@ func (n *Netlify) uploadFiles(ctx context.Context, d *models.Deploy, files *depl
 	count := 0
 	for _, sha := range required {
 		if files, exist := files.Hashed[sha]; exist {
-			for range files {
-				count++
-			}
+			count = count + len(files)
 		}
 	}
 


### PR DESCRIPTION
remove extra unnecessary iteration over files