### PR TITLE
fix: race condition when waiting for sharedError

### DIFF
--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -405,7 +405,6 @@ func (n *Netlify) uploadFiles(ctx context.Context, d *models.Deploy, files *depl
 	sharedErr := &uploadError{err: nil, mutex: &sync.Mutex{}}
 	sem := make(chan int, n.uploadLimit)
 	wg := &sync.WaitGroup{}
-	defer wg.Wait()
 
 	var required []string
 	switch t {
@@ -446,6 +445,8 @@ func (n *Netlify) uploadFiles(ctx context.Context, d *models.Deploy, files *depl
 			}
 		}
 	}
+
+	wg.Wait()
 
 	return sharedErr.err
 }


### PR DESCRIPTION
While debugging [an issue with some files failing to upload](https://github.com/netlify/buildbot/issues/2793) we encountered that when calling: `defer wg.Wait()`
having a `return` statement, the return value would be assigned first, and then we would wait for the wait group, you can explore this issue on this playground link: https://go.dev/play/p/nuOytLQbkQy

Why it did not affect every single deploy?
Some Deploys returned some errors because they were blocked here: https://github.com/netlify/open-api/blob/master/go/porcelain/deploy.go#L433-L435 due to having too many files and waiting for the initialized semaphore, giving it a chance for `sharedErr` to have a value assigned before it be assigned to the `return` statement.

