### PR TITLE
Add Repo field in site model

### DIFF
--- a/go/models/site.go
+++ b/go/models/site.go
@@ -94,6 +94,9 @@ type Site struct {
 	// published deploy
 	PublishedDeploy *Deploy `json:"published_deploy,omitempty"`
 
+	// repository settings
+	Repo *RepoInfo `json:"repo,omitempty"`
+
 	// screenshot url
 	ScreenshotURL string `json:"screenshot_url,omitempty"`
 


### PR DESCRIPTION
Without this field, it's not possible to create a site and link a repository using the porcelain client.
I had to edit the client to make this work: https://answers.netlify.com/t/support-guide-linking-a-repository-via-api/121
Thanks :)