### PR TITLE
 fix: fileUpload error casting does not conform to interface 

### DIFF
--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	apierrors "github.com/go-openapi/errors"
 	"github.com/pkg/errors"
 	"github.com/rsc/goversion/version"
 	"github.com/sirupsen/logrus"
@@ -98,6 +97,11 @@ type DeployOptions struct {
 	functions         *deployFiles
 	functionSchedules []*models.FunctionSchedule
 	functionsConfig   map[string]models.FunctionConfig
+}
+
+type deployApiError interface {
+	error
+	Code() int
 }
 
 type uploadError struct {
@@ -537,7 +541,7 @@ func (n *Netlify) uploadFile(ctx context.Context, d *models.Deploy, f *FileBundl
 
 		if operationError != nil {
 			context.GetLogger(ctx).WithError(operationError).Errorf("Failed to upload file %v", f.Name)
-			apiErr, ok := operationError.(apierrors.Error)
+			apiErr, ok := operationError.(deployApiError)
 
 			if ok && apiErr.Code() == 401 {
 				sharedErr.mutex.Lock()


### PR DESCRIPTION
Trying to debug the issues face by the dev-foundations team on this PR: https://github.com/netlify/open-api/pull/478#discussion_r1316212994

I noticed that the interface in`apierrors.Error` has different function signatures than the types returned by `UploadDeployFile` and `UploadDeployFunction`

since we do safe casting `.()` this failed silently and went unnoticed.


In this changes I implement an interface that matches the signature of the errors returned by those two functions and defined the function we need to use (`Code() int`)