### PR TITLE
feat(go-client): add poll for processed

### DIFF
--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -403,9 +403,14 @@ func (n *Netlify) WaitUntilDeployReady(ctx context.Context, d *models.Deploy) (*
 	return n.waitForState(ctx, d, "prepared", "ready")
 }
 
-// WaitUntilDeployLive blocks until the deploy is in the "ready" state. At this point, the deploy is ready to recieve traffic.
+// WaitUntilDeployLive blocks until the deploy is in the "ready" state. At this point, the deploy is ready to receive traffic to all of its URLs.
 func (n *Netlify) WaitUntilDeployLive(ctx context.Context, d *models.Deploy) (*models.Deploy, error) {
 	return n.waitForState(ctx, d, "ready")
+}
+
+// WaitUntilDeployProcessed blocks until the deploy is in the "processed" state. At this point, the deploy is ready to receive traffic via its permalink.
+func (n *Netlify) WaitUntilDeployProcessed(ctx context.Context, d *models.Deploy) (*models.Deploy, error) {
+	return n.waitForState(ctx, d, "processed")
 }
 
 func (n *Netlify) uploadFiles(ctx context.Context, d *models.Deploy, files *deployFiles, observer DeployObserver, t uploadType, timeout time.Duration, skipRetry bool) error {

--- a/swagger.yml
+++ b/swagger.yml
@@ -935,6 +935,7 @@ paths:
           - preparing
           - prepared
           - processing
+          - processed
           - ready
           - error
           - retrying


### PR DESCRIPTION
Related with - https://github.com/netlify/buildbot/issues/2886

Adds a porcelain utility method to poll for state `processed`.