### PR TITLE
feat: Add build data for observability

### DIFF
--- a/go/models/create_env_vars_params_body_items.go
+++ b/go/models/create_env_vars_params_body_items.go
@@ -20,7 +20,7 @@ import (
 // swagger:model createEnvVarsParamsBodyItems
 type CreateEnvVarsParamsBodyItems struct {
 
-	// Secret values are only readable by code running on Netlify’s systems.  With secrets, only the local development context values are readable from the UI, API, and CLI. By default, environment variable values are not secret. (Enterprise plans only)
+	// Secret values are only readable by code running on Netlify’s systems. With secrets, only the local development context values are readable from the UI, API, and CLI. By default, environment variable values are not secret. (Enterprise plans only)
 	IsSecret bool `json:"is_secret,omitempty"`
 
 	// The existing or new name of the key, if you wish to rename it (case-sensitive)

--- a/go/models/env_var.go
+++ b/go/models/env_var.go
@@ -20,7 +20,7 @@ import (
 // swagger:model envVar
 type EnvVar struct {
 
-	// Secret values are only readable by code running on Netlify’s systems.  With secrets, only the local development context values are readable from the UI, API, and CLI. By default, environment variable values are not secret. (Enterprise plans only)
+	// Secret values are only readable by code running on Netlify’s systems. With secrets, only the local development context values are readable from the UI, API, and CLI. By default, environment variable values are not secret. (Enterprise plans only)
 	IsSecret bool `json:"is_secret,omitempty"`
 
 	// The environment variable key, like ALGOLIA_ID (case-sensitive)

--- a/go/models/function_config.go
+++ b/go/models/function_config.go
@@ -18,6 +18,9 @@ import (
 // swagger:model functionConfig
 type FunctionConfig struct {
 
+	// build data
+	BuildData interface{} `json:"build_data,omitempty"`
+
 	// display name
 	DisplayName string `json:"display_name,omitempty"`
 

--- a/go/models/update_env_var_params_body.go
+++ b/go/models/update_env_var_params_body.go
@@ -20,7 +20,7 @@ import (
 // swagger:model updateEnvVarParamsBody
 type UpdateEnvVarParamsBody struct {
 
-	// Secret values are only readable by code running on Netlify’s systems.  With secrets, only the local development context values are readable from the UI, API, and CLI. By default, environment variable values are not secret. (Enterprise plans only)
+	// Secret values are only readable by code running on Netlify’s systems. With secrets, only the local development context values are readable from the UI, API, and CLI. By default, environment variable values are not secret. (Enterprise plans only)
 	IsSecret bool `json:"is_secret,omitempty"`
 
 	// The existing or new name of the key, if you wish to rename it (case-sensitive)

--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -821,11 +821,12 @@ func bundleFromManifest(ctx context.Context, manifestFile *os.File, observer Dep
 			}
 		}
 
-		if function.DisplayName != "" || function.Generator != "" || len(routes) > 0 {
+		if function.DisplayName != "" || function.Generator != "" || len(routes) > 0 || len(function.BuildData) > 0 {
 			functionsConfig[file.Name] = models.FunctionConfig{
 				DisplayName: function.DisplayName,
 				Generator:   function.Generator,
 				Routes:      routes,
+				BuildData:   function.BuildData,
 			}
 		}
 

--- a/go/porcelain/deploy_test.go
+++ b/go/porcelain/deploy_test.go
@@ -639,6 +639,7 @@ func TestBundleWithManifest(t *testing.T) {
 				"mainFile": "/some/path/hello-js-function-test.js",
 				"displayName": "Hello Javascript Function",
 				"generator": "@netlify/fake-plugin@1.0.0",
+				"buildData": { "runtimeAPIVersion": 2 },
 				"name": "hello-js-function-test",
 				"schedule": "* * * * *",
 				"routes": [
@@ -686,6 +687,7 @@ func TestBundleWithManifest(t *testing.T) {
 	assert.Equal(t, 1, len(functionsConfig))
 	assert.Equal(t, "Hello Javascript Function", helloJSConfig.DisplayName)
 	assert.Equal(t, "@netlify/fake-plugin@1.0.0", helloJSConfig.Generator)
+	assert.EqualValues(t, 2, helloJSConfig.BuildData.(map[string]interface{})["runtimeAPIVersion"])
 
 	assert.Equal(t, "/products", helloJSConfig.Routes[0].Pattern)
 	assert.Equal(t, "/products", helloJSConfig.Routes[0].Literal)

--- a/go/porcelain/functions_manifest.go
+++ b/go/porcelain/functions_manifest.go
@@ -7,16 +7,17 @@ type functionsManifest struct {
 }
 
 type functionsManifestEntry struct {
-	MainFile       string          `json:"mainFile"`
-	Name           string          `json:"name"`
-	Path           string          `json:"path"`
-	Runtime        string          `json:"runtime"`
-	RuntimeVersion string          `json:"runtimeVersion"`
-	Schedule       string          `json:"schedule"`
-	DisplayName    string          `json:"displayName"`
-	Generator      string          `json:"generator"`
-	InvocationMode string          `json:"invocationMode"`
-	Routes         []functionRoute `json:"routes"`
+	MainFile       string                 `json:"mainFile"`
+	Name           string                 `json:"name"`
+	Path           string                 `json:"path"`
+	Runtime        string                 `json:"runtime"`
+	RuntimeVersion string                 `json:"runtimeVersion"`
+	Schedule       string                 `json:"schedule"`
+	DisplayName    string                 `json:"displayName"`
+	Generator      string                 `json:"generator"`
+	BuildData      map[string]interface{} `json:"buildData"`
+	InvocationMode string                 `json:"invocationMode"`
+	Routes         []functionRoute        `json:"routes"`
 }
 
 type functionRoute struct {

--- a/swagger.yml
+++ b/swagger.yml
@@ -283,7 +283,7 @@ paths:
                 is_secret:
                   type: boolean
                   description: >-
-                    Secret values are only readable by code running on Netlify’s systems. 
+                    Secret values are only readable by code running on Netlify’s systems.
                     With secrets, only the local development context values are readable from the UI, API, and CLI.
                     By default, environment variable values are not secret. (Enterprise plans only)
         - name: account_id
@@ -387,7 +387,7 @@ paths:
               is_secret:
                 type: boolean
                 description: >-
-                  Secret values are only readable by code running on Netlify’s systems. 
+                  Secret values are only readable by code running on Netlify’s systems.
                   With secrets, only the local development context values are readable from the UI, API, and CLI.
                   By default, environment variable values are not secret. (Enterprise plans only)
         - name: site_id
@@ -2738,7 +2738,7 @@ definitions:
       is_secret:
         type: boolean
         description: >-
-          Secret values are only readable by code running on Netlify’s systems. 
+          Secret values are only readable by code running on Netlify’s systems.
           With secrets, only the local development context values are readable from the UI, API, and CLI.
           By default, environment variable values are not secret. (Enterprise plans only)
       updated_at:
@@ -3621,10 +3621,12 @@ definitions:
         type: string
       generator:
         type: string
+      build_data:
+        type: object
       routes:
         type: array
         items:
-          $ref: '#/definitions/functionRoute'      
+          $ref: '#/definitions/functionRoute'
   functionRoute:
     type: object
     properties:
@@ -3633,7 +3635,7 @@ definitions:
       literal:
         type: string
       expression:
-        type: string    
+        type: string
       methods:
         type: array
         items:


### PR DESCRIPTION
Adds build data to surface information about the serverless functions api and netlify/build

Part of https://linear.app/netlify/issue/COM-6/expose-the-ability-to-query-for-functions-using-the-v2-api