### PR TITLE
Add `buildbot_version` and `build_version` to notifyBuildStart

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -1200,6 +1200,14 @@ paths:
         type: string
         in: path
         required: true
+      - name: buildbot_version
+        type: string
+        in: query
+        required: false
+      - name: build_version
+        type: string
+        in: query
+        required: false
     post:
       operationId: notifyBuildStart
       tags: [build]


### PR DESCRIPTION
Adds two parameters that we can use to pass version information from buildbot into bitballoon. See https://github.com/netlify/bitballoon/pull/16714#issuecomment-1738921918 for more context.