### PR TITLE
fix: upload non-zisi-compiled files as `provided.al2`

### DIFF
--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -746,7 +746,7 @@ func bundle(ctx context.Context, functionDir string, observer DeployObserver) (*
 			}
 			functions.Add(file.Name, file)
 		case goFile(filePath, i, observer):
-			file, err := newFunctionFile(filePath, i, goRuntime, nil, observer)
+			file, err := newFunctionFile(filePath, i, amazonLinux2, nil, observer)
 			if err != nil {
 				return nil, nil, nil, err
 			}
@@ -975,14 +975,7 @@ func ignoreFile(rel string, ignoreInstallDirs bool) bool {
 }
 
 func createHeader(archive *zip.Writer, i os.FileInfo, runtime string) (io.Writer, error) {
-	if runtime == goRuntime {
-		return archive.CreateHeader(&zip.FileHeader{
-			CreatorVersion: 3 << 8,     // indicates Unix
-			ExternalAttrs:  0777 << 16, // -rwxrwxrwx file permissions
-			Name:           i.Name(),
-			Method:         zip.Deflate,
-		})
-	} else if runtime == amazonLinux2 {
+	if runtime == goRuntime || runtime == amazonLinux2 {
 		return archive.CreateHeader(&zip.FileHeader{
 			CreatorVersion: 3 << 8,     // indicates Unix
 			ExternalAttrs:  0777 << 16, // -rwxrwxrwx file permissions

--- a/go/porcelain/deploy_test.go
+++ b/go/porcelain/deploy_test.go
@@ -624,7 +624,7 @@ func TestBundle(t *testing.T) {
 	assert.Equal(t, "js", jsFunction.Runtime)
 	assert.Equal(t, "py", pyFunction.Runtime)
 	assert.Equal(t, "rs", rsFunction.Runtime)
-	assert.Equal(t, "go", goFunction.Runtime)
+	assert.Equal(t, "provided.al2", goFunction.Runtime)
 }
 
 func TestBundleWithManifest(t *testing.T) {


### PR DESCRIPTION
In https://github.com/netlify/open-api/pull/490, we made the switch to upload ZISI-compiled Go functions as `provided.al2`. This has been rolled out successfully, so now we can also make this switch for files that weren't compiled by ZISI.

Part of https://github.com/netlify/pod-dev-foundations/issues/581.