### PR TITLE
feat: Added framework_version

### DIFF
--- a/go/models/deploy_files.go
+++ b/go/models/deploy_files.go
@@ -34,6 +34,9 @@ type DeployFiles struct {
 	// framework
 	Framework string `json:"framework,omitempty"`
 
+	// framework version
+	FrameworkVersion string `json:"framework_version,omitempty"`
+
 	// function schedules
 	FunctionSchedules []*FunctionSchedule `json:"function_schedules"`
 

--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -91,6 +91,7 @@ type DeployOptions struct {
 	Branch            string
 	CommitRef         string
 	Framework         string
+	FrameworkVersion  string
 	UploadTimeout     time.Duration
 	PreProcessTimeout time.Duration
 
@@ -262,10 +263,11 @@ func (n *Netlify) DoDeploy(ctx context.Context, options *DeployOptions, deploy *
 	options.functionsConfig = functionsConfig
 
 	deployFiles := &models.DeployFiles{
-		Files:     options.files.Sums,
-		Draft:     options.IsDraft,
-		Async:     n.overCommitted(options.files),
-		Framework: options.Framework,
+		Files:            options.files.Sums,
+		Draft:            options.IsDraft,
+		Async:            n.overCommitted(options.files),
+		Framework:        options.Framework,
+		FrameworkVersion: options.FrameworkVersion,
 	}
 	if options.functions != nil {
 		deployFiles.Functions = options.functions.Sums

--- a/swagger.yml
+++ b/swagger.yml
@@ -3036,6 +3036,8 @@ definitions:
         type: string
       framework:
         type: string
+      framework_version:
+        type: string
   pluginParams:
     type: object
     properties:


### PR DESCRIPTION
Issue: https://linear.app/netlify/issue/COM-75/add-framework-version-parameter-to-open-api-deployfiles

The new field it's added to the deploy files. The framework is added [here](https://github.com/netlify/open-api/blob/b041a0fd6b17bd8d21529240110f146a430bd789/go/porcelain/deploy.go#L268) as well, but I think that's just for deploy creation? And we will be updating the deploy 