### PR TITLE
chore(docs): output OpenAPI v3 spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -246,9 +246,9 @@
       "dev": true
     },
     "@exodus/schemasafe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.1.tgz",
-      "integrity": "sha512-PQdbF8dGd4LnbwBlcc4ML8RKYdplm+e9sUeWBTr4zgF13/Shiuov9XznvM4T8cb1CfyKK21yTUkuAIIh/DAH/g==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
+      "integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==",
       "dev": true
     },
     "@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "make-dir": "^3.0.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.7",
-    "swagger-parser": "^8.0.1"
+    "swagger-parser": "^8.0.1",
+    "swagger2openapi": "^7.0.8"
   },
   "files": [],
   "homepage": "https://github.com/netlify/open-api#readme",
@@ -48,6 +49,7 @@
     "start": "run-s lint build",
     "bundle": "redocly bundle external@latest --output external.yml",
     "build": "run-s convert bundle redoc",
+    "postbuild": "swagger2openapi external.yml -o dist/openapi.json",
     "convert": "node src/convert.js",
     "bump-swagger": "node src/bump-swagger.js",
     "redoc": "node src/docs/build.js",


### PR DESCRIPTION
Replicates the results of clicking the "Download" button in the UI, so that the OpenAPI v3 spec can be accessed directly

## Test plan

- [ ] [Visit the Deploy Preview](https://deploy-preview-521--open-api.netlify.com) and verify that [`/openapi.json`](https://deploy-preview-521--open-api.netlify.com/openapi.json) is accessible, and returns a valid OpenAPI v3 spec