### PR TITLE
feat: remove site_capabilities from the deploy object

### DIFF
--- a/go/models/deploy.go
+++ b/go/models/deploy.go
@@ -84,9 +84,6 @@ type Deploy struct {
 	// screenshot url
 	ScreenshotURL string `json:"screenshot_url,omitempty"`
 
-	// site capabilities
-	SiteCapabilities *DeploySiteCapabilities `json:"site_capabilities,omitempty"`
-
 	// site id
 	SiteID string `json:"site_id,omitempty"`
 
@@ -120,10 +117,6 @@ func (m *Deploy) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateSiteCapabilities(formats); err != nil {
-		res = append(res, err)
-	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -150,24 +143,6 @@ func (m *Deploy) validateFunctionSchedules(formats strfmt.Registry) error {
 			}
 		}
 
-	}
-
-	return nil
-}
-
-func (m *Deploy) validateSiteCapabilities(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.SiteCapabilities) { // not required
-		return nil
-	}
-
-	if m.SiteCapabilities != nil {
-		if err := m.SiteCapabilities.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("site_capabilities")
-			}
-			return err
-		}
 	}
 
 	return nil

--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -209,10 +209,6 @@ func (n *Netlify) DoDeploy(ctx context.Context, options *DeployOptions, deploy *
 	}
 
 	largeMediaEnabled := options.LargeMediaEnabled
-	if !largeMediaEnabled && deploy != nil {
-		largeMediaEnabled = deploy.SiteCapabilities.LargeMediaEnabled
-	}
-
 	ignoreInstallDirs := options.Dir == options.BuildDir
 
 	context.GetLogger(ctx).Infof("Getting files info with large media flag: %v", largeMediaEnabled)

--- a/swagger.yml
+++ b/swagger.yml
@@ -3056,11 +3056,6 @@ definitions:
         type: boolean
       review_url:
         type: string
-      site_capabilities:
-        type: object
-        properties:
-          large_media_enabled:
-            type: boolean
       framework:
         type: string
       function_schedules:


### PR DESCRIPTION
This was used just for large media and we're deprecating it. We'll be removing this slowly and this is a good first step and allows us to return a smaller object for deploys.

Updated the porcelain handler to not rely on this field but only on the option passed on DoDeploy. This way we allow for builds to still use it if needed until fully retired.