### PR TITLE
fix: use correct casing in excluded routes property

### DIFF
--- a/go/porcelain/functions_manifest.go
+++ b/go/porcelain/functions_manifest.go
@@ -21,7 +21,7 @@ type functionsManifestEntry struct {
 	BuildData      map[string]interface{}  `json:"buildData"`
 	InvocationMode string                  `json:"invocationMode"`
 	Routes         []functionRoute         `json:"routes"`
-	ExcludedRoutes []excludedFunctionRoute `json:"excluded_routes"`
+	ExcludedRoutes []excludedFunctionRoute `json:"excludedRoutes"`
 	Priority       int                     `json:"priority"`
 	TrafficRules   *functionTrafficRules   `json:"trafficRules"`
 }


### PR DESCRIPTION
The functions manifest uses camelCase! 🤦🏻 