### PR TITLE
fix(getSite): add account_id to the list of returned props

### DIFF
--- a/go/models/site.go
+++ b/go/models/site.go
@@ -16,6 +16,9 @@ import (
 // swagger:model site
 type Site struct {
 
+	// account id
+	AccountID string `json:"account_id,omitempty"`
+
 	// account name
 	AccountName string `json:"account_name,omitempty"`
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -2857,6 +2857,8 @@ definitions:
         type: string
       published_deploy:
         $ref: '#/definitions/deploy'
+      account_id:
+        type: string
       account_name:
         type: string
       account_slug:


### PR DESCRIPTION
Part of FRP-1269 - https://linear.app/netlify/issue/FRP-1269/information-request-is-the-account-id-available-for-build-plugins - as I was looking through the properties we return on the get site endpoint I noticed we're not listing the `account_id` (and we are returning it already) this just clarifies that and updates our open API spec.