### PR TITLE
fix: update `getCurrentUser` response type from array to single `User` object

### DIFF
--- a/go/plumbing/operations/get_current_user_responses.go
+++ b/go/plumbing/operations/get_current_user_responses.go
@@ -52,21 +52,23 @@ GetCurrentUserOK handles this case with default header values.
 OK
 */
 type GetCurrentUserOK struct {
-	Payload []*models.User
+	Payload *models.User
 }
 
 func (o *GetCurrentUserOK) Error() string {
 	return fmt.Sprintf("[GET /user][%d] getCurrentUserOK  %+v", 200, o.Payload)
 }
 
-func (o *GetCurrentUserOK) GetPayload() []*models.User {
+func (o *GetCurrentUserOK) GetPayload() *models.User {
 	return o.Payload
 }
 
 func (o *GetCurrentUserOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(models.User)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -2275,8 +2275,7 @@ paths:
         '200':
           description: OK
           schema:
-            items:
-              $ref: '#/definitions/user'
+            $ref: '#/definitions/user'
         default:
           $ref: '#/responses/error'
   # end users

--- a/swagger.yml
+++ b/swagger.yml
@@ -2275,7 +2275,6 @@ paths:
         '200':
           description: OK
           schema:
-            type: array
             items:
               $ref: '#/definitions/user'
         default:


### PR DESCRIPTION
`getCurrentUser` response schema was incorrectly set as an array but should just be a single user object.