### PR TITLE
fix: update `getAccount` response type from array to single account object

### DIFF
--- a/go/plumbing/operations/get_account_responses.go
+++ b/go/plumbing/operations/get_account_responses.go
@@ -52,21 +52,23 @@ GetAccountOK handles this case with default header values.
 OK
 */
 type GetAccountOK struct {
-	Payload []*models.AccountMembership
+	Payload *models.AccountMembership
 }
 
 func (o *GetAccountOK) Error() string {
 	return fmt.Sprintf("[GET /accounts/{account_id}][%d] getAccountOK  %+v", 200, o.Payload)
 }
 
-func (o *GetAccountOK) GetPayload() []*models.AccountMembership {
+func (o *GetAccountOK) GetPayload() *models.AccountMembership {
 	return o.Payload
 }
 
 func (o *GetAccountOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(models.AccountMembership)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -2054,9 +2054,7 @@ paths:
         '200':
           description: OK
           schema:
-            type: array
-            items:
-              $ref: '#/definitions/accountMembership'
+            $ref: '#/definitions/accountMembership'
         default:
           $ref: '#/responses/error'
     put:


### PR DESCRIPTION
## Summary

This PR fixes the incorrect response type for the `getAccount` endpoint in the OpenAPI specification.

## Problem

The `getAccount` endpoint was incorrectly documented as returning an array of `accountMembership` objects:

```yaml
schema:
  type: array
  items:
    $ref: '#/definitions/accountMembership'
```

However, the actual API returns a single `accountMembership` object, not an array.

## Solution

Updated the response schema to correctly reflect a single object:

```yaml
schema:
  $ref: '#/definitions/accountMembership'
```

This change brings the `getAccount` endpoint in line with other similar single-object endpoints like:
- `createAccount`
- `updateAccount` 
- `getCurrentUser`

## Testing

- ✅ All existing tests pass
- ✅ Build process completes successfully
- ✅ Generated TypeScript types are correct
- ✅ Documentation builds without errors

## Impact

This fix will:
- Correct the generated TypeScript types (used in the js client `@netlify/api`)
- Update the API documentation to reflect actual behavior
- Prevent confusion for developers using the API

Fixes #567

### Before
<img width="616" alt="image" src="https://github.com/user-attachments/assets/01411c37-99cb-4a51-a694-793f642f026d" />

### After
<img width="615" alt="image" src="https://github.com/user-attachments/assets/db835d84-d8fe-4878-bc76-ecb09718302d" />
