### PR TITLE
fix: bug in path for fetch gateway token 

### DIFF
--- a/go/plumbing/operations/get_a_i_gateway_token_responses.go
+++ b/go/plumbing/operations/get_a_i_gateway_token_responses.go
@@ -62,7 +62,7 @@ type GetAIGatewayTokenOK struct {
 }
 
 func (o *GetAIGatewayTokenOK) Error() string {
-	return fmt.Sprintf("[GET /api/v1/sites/{site_id}/ai-gateway/token][%d] getAIGatewayTokenOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /sites/{site_id}/ai-gateway/token][%d] getAIGatewayTokenOK  %+v", 200, o.Payload)
 }
 
 func (o *GetAIGatewayTokenOK) GetPayload() *models.AiGatewayToken {
@@ -95,7 +95,7 @@ type GetAIGatewayTokenNotFound struct {
 }
 
 func (o *GetAIGatewayTokenNotFound) Error() string {
-	return fmt.Sprintf("[GET /api/v1/sites/{site_id}/ai-gateway/token][%d] getAIGatewayTokenNotFound ", 404)
+	return fmt.Sprintf("[GET /sites/{site_id}/ai-gateway/token][%d] getAIGatewayTokenNotFound ", 404)
 }
 
 func (o *GetAIGatewayTokenNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -127,7 +127,7 @@ func (o *GetAIGatewayTokenDefault) Code() int {
 }
 
 func (o *GetAIGatewayTokenDefault) Error() string {
-	return fmt.Sprintf("[GET /api/v1/sites/{site_id}/ai-gateway/token][%d] getAIGatewayToken default  %+v", o._statusCode, o.Payload)
+	return fmt.Sprintf("[GET /sites/{site_id}/ai-gateway/token][%d] getAIGatewayToken default  %+v", o._statusCode, o.Payload)
 }
 
 func (o *GetAIGatewayTokenDefault) GetPayload() *models.Error {

--- a/go/plumbing/operations/operations_client.go
+++ b/go/plumbing/operations/operations_client.go
@@ -2148,7 +2148,7 @@ func (a *Client) GetAIGatewayToken(params *GetAIGatewayTokenParams, authInfo run
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "getAIGatewayToken",
 		Method:             "GET",
-		PathPattern:        "/api/v1/sites/{site_id}/ai-gateway/token",
+		PathPattern:        "/sites/{site_id}/ai-gateway/token",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"https"},

--- a/swagger.yml
+++ b/swagger.yml
@@ -3144,7 +3144,7 @@ paths:
                   $ref: '#/definitions/providerDefinition'
         default:
           $ref: '#/responses/error'
-  /api/v1/sites/{site_id}/ai-gateway/token:
+  /sites/{site_id}/ai-gateway/token:
     parameters:
       - name: site_id
         type: string


### PR DESCRIPTION
path is duplicating the base `/api/v1` 🤦‍♀️ 