### PR TITLE
fix: stop zipping tar files

### DIFF
--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -917,7 +917,7 @@ func newFunctionFile(filePath string, i os.FileInfo, runtime string, metadata *F
 
 	var buf io.ReadWriter
 
-	if zipFile(i) {
+	if zipFile(i) || tarFile(i) {
 		buf = fileEntry
 	} else {
 		buf = new(bytes.Buffer)
@@ -959,6 +959,12 @@ func newFunctionFile(filePath string, i os.FileInfo, runtime string, metadata *F
 
 func zipFile(i os.FileInfo) bool {
 	return filepath.Ext(i.Name()) == ".zip"
+}
+
+func tarFile(i os.FileInfo) bool {
+	name := i.Name()
+	ext := filepath.Ext(name)
+	return ext == ".tar" || ext == ".tgz" || strings.HasSuffix(name, ".tar.gz")
 }
 
 func jsFile(i os.FileInfo) bool {


### PR DESCRIPTION
The Go client has some legacy logic for handling non-ZIP files and creating a ZIP archive around them. So anything that isn't a `.zip` gets that treatment.

This is problematic when we add support for other archive formats, which is the case with the `.tgz` files used by Play.

So while this logic is mostly legacy at this point — since I think even Go functions are now zipped by zip-it-and-ship-it — I'm keeping it and just adding a special case for tar files. When we detect them, leave them alone and don't wrap them in a ZIP.