### PR TITLE
fix: require is_secret attribute on deploy environment variables

### DIFF
--- a/go/models/deploy_environment_variable.go
+++ b/go/models/deploy_environment_variable.go
@@ -21,7 +21,8 @@ import (
 type DeployEnvironmentVariable struct {
 
 	// is secret
-	IsSecret bool `json:"is_secret,omitempty"`
+	// Required: true
+	IsSecret *bool `json:"is_secret"`
 
 	// key
 	// Required: true
@@ -40,6 +41,10 @@ type DeployEnvironmentVariable struct {
 func (m *DeployEnvironmentVariable) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateIsSecret(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateKey(formats); err != nil {
 		res = append(res, err)
 	}
@@ -55,6 +60,15 @@ func (m *DeployEnvironmentVariable) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *DeployEnvironmentVariable) validateIsSecret(formats strfmt.Registry) error {
+
+	if err := validate.Required("is_secret", "body", m.IsSecret); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/go/porcelain/deploy.go
+++ b/go/porcelain/deploy.go
@@ -43,9 +43,9 @@ const (
 
 	lfsVersionString = "version https://git-lfs.github.com/spec/v1"
 
-	edgeFunctionsInternalPath  = ".netlify/internal/edge-functions/"
-	edgeRedirectsInternalPath  = ".netlify/deploy-config/"
-	dbMigrationsInternalPath   = ".netlify/internal/db/migrations/"
+	edgeFunctionsInternalPath = ".netlify/internal/edge-functions/"
+	edgeRedirectsInternalPath = ".netlify/deploy-config/"
+	dbMigrationsInternalPath  = ".netlify/internal/db/migrations/"
 )
 
 var installDirs = []string{"node_modules/", "bower_components/"}
@@ -75,12 +75,6 @@ type DeployObserver interface {
 
 type DeployWarner interface {
 	OnWalkWarning(path, msg string)
-}
-
-type DeployEnvironmentVariable struct {
-	Key      string
-	Value    string
-	IsSecret bool
 }
 
 // DeployOptions holds the option for creating a new deploy

--- a/swagger.yml
+++ b/swagger.yml
@@ -4152,6 +4152,7 @@ definitions:
       - key
       - value
       - scopes
+      - is_secret
     properties:
       key:
         type: string


### PR DESCRIPTION
This attribute is always required by the API and so omitting it, even
when false or defaulting to false, results in an API error.

I've also cleaned up an unused type from the porcelain package.
