### PR TITLE
chore: add context7.json to claim Context7 ownership

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/netlify/open-api",
+  "public_key": "pk_o1kJHj61VuNZdp8u5vsq0"
+}


### PR DESCRIPTION
Adds a `context7.json` to the repo root to claim ownership of this project on Context7.

Once merged, manage the Context7 entry here: https://context7.com/netlify/open-api/admin

Linear: [AX-44](https://linear.app/netlify/issue/AX-44)